### PR TITLE
Limit fields that can be passed to the constructor

### DIFF
--- a/limpyd/model.py
+++ b/limpyd/model.py
@@ -87,6 +87,8 @@ class RedisModel(RedisProxyCommand):
             # redis do not has "real" transactions)
             # Here we do not set anything, in case one unique field fails
             for field_name, value in kwargs.iteritems():
+                if field_name not in self._fields:
+                    raise ValueError(u"`%s` is not a valid field name" % field_name)
                 field = getattr(self, field_name)
                 if field.unique and self.exists(**{field_name: value}):
                     raise UniquenessError(u"Field `%s` must be unique. "


### PR DESCRIPTION
Add a test in the `RedisModel` constructor to deny not real fields to be passed as `kwargs`, to avoid useless call to `getattr`, and return a clean error message (a `ValueError` exception)
