### PR TITLE
Add configuration of connections (and share them)

### DIFF
--- a/limpyd/fields.py
+++ b/limpyd/fields.py
@@ -2,7 +2,7 @@
 
 from logging import getLogger
 
-from limpyd import get_connection
+from limpyd import redis_connect, DEFAULT_CONNECTION_SETTINGS
 from limpyd.utils import make_key, memoize_command
 from limpyd.exceptions import *
 
@@ -66,6 +66,22 @@ class RedisProxyCommand(object):
     def post_command(self, sender, name, result, args, kwargs):
         return result
 
+    @classmethod
+    def get_connection(cls):
+        """
+        Create (or get from cache) a redis connection with settings set on the
+        class via CONNECTION_SETTINGS, or use the default ones
+        """
+        return redis_connect(getattr(cls, 'CONNECTION_SETTINGS', {}) or DEFAULT_CONNECTION_SETTINGS)
+
+    @property
+    def connection(self):
+        """
+        A simple property on the instance that return the connection stored on
+        the class
+        """
+        return self.get_connection()
+
     class transaction(object):
 
         def __init__(self, instance):
@@ -118,9 +134,9 @@ class RedisField(RedisProxyCommand):
 
     @property
     def connection(self):
-        if not self._instance:
-            raise TypeError('Cannot use connection without instance')
-        return self._instance.connection
+        if not self._model:
+            raise TypeError('A field cannot use a connection if not linked to a model')
+        return self._model.get_connection()
 
     def __copy__(self):
         """
@@ -130,7 +146,7 @@ class RedisField(RedisProxyCommand):
         attributes, without ignoring private attributes
         """
         new_copy = self.__class__(**self.__dict__)
-        for attr_name in ('name', '_instance', '_parent_class'):
+        for attr_name in ('name', '_instance', '_model'):
             if hasattr(self, attr_name):
                 setattr(new_copy, attr_name, getattr(self, attr_name))
         return new_copy
@@ -231,7 +247,7 @@ class IndexableField(RedisField):
         if not self.indexable:
             raise ValueError("Field %s is not indexable, cannot ask its index_key" % self.name)
         return self.make_key(
-            self._parent_class,
+            self._model._name,
             self.name,
             value,
         )
@@ -343,7 +359,7 @@ class PKField(RedisField):
         """
         if value is None:
             raise ValueError('The pk for %s is not "auto-increment", you must fill it' % \
-                            self._parent_class)
+                            self._model._name)
         return value
 
     @property
@@ -352,19 +368,19 @@ class PKField(RedisField):
         Property that return the name of the key in Redis where are stored
         all the exinsting pk for the model hosting this PKField
         """
-        return '%s:collection' % self._parent_class
+        return '%s:collection' % self._model._name
 
     def exists(self, value):
         """
         Return True if the given pk value exists for the given class
         """
-        return get_connection().sismember(self.collection_key, value)
+        return self.connection.sismember(self.collection_key, value)
 
     def collection(self):
         """
         Return all available primary keys for the given class
         """
-        return get_connection().smembers(self.collection_key)
+        return self.connection.smembers(self.collection_key)
 
     def set(self, value):
         """
@@ -391,7 +407,7 @@ class PKField(RedisField):
         self._set = True
 
         # We have a new pk, so add it to the collection
-        log.debug("Adding %s in %s collection" % (value, self._parent_class))
+        log.debug("Adding %s in %s collection" % (value, self._model._name))
         self.connection.sadd(self.collection_key, value)
 
         # Finally return 1 as we did a real redis call to the set command
@@ -420,6 +436,6 @@ class AutoPKField(PKField):
         """
         if value is not None:
             raise ValueError('The pk for %s is "auto-increment", you must not fill it' % \
-                            self._parent_class)
-        key = self._instance.make_key(self._parent_class, 'max_pk')
+                            self._model._name)
+        key = self._instance.make_key(self._model._name, 'max_pk')
         return self.connection.incr(key)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,18 +1,17 @@
 import unittest
 
-from limpyd import ConnectionSettings, TESTS_DB_ID, PROD_DB_ID, get_connection
+from limpyd import DEFAULT_CONNECTION_SETTINGS, TEST_CONNECTION_SETTINGS, redis_connect
 
 
 class LimpydBaseTest(unittest.TestCase):
 
     def setUp(self):
         # FIXME: is it tread safe?
-        ConnectionSettings.DB_ID = TESTS_DB_ID
-        self.connection = get_connection()
+        self.connection = redis_connect(TEST_CONNECTION_SETTINGS)
         # Ensure that we are on the right DB before flushing
         current_db_id = self.connection.connection_pool.connection_kwargs['db']
-        assert current_db_id != PROD_DB_ID
-        assert current_db_id == TESTS_DB_ID
+        assert current_db_id != DEFAULT_CONNECTION_SETTINGS['db']
+        assert current_db_id == TEST_CONNECTION_SETTINGS['db']
         self.connection.flushdb()
 
     def tearDown(self):

--- a/tests/model.py
+++ b/tests/model.py
@@ -7,10 +7,18 @@ from datetime import datetime
 from limpyd import model
 from limpyd import fields
 from limpyd.exceptions import *
-from base import LimpydBaseTest
+from base import LimpydBaseTest, TEST_CONNECTION_SETTINGS
 
 
-class Bike(model.RedisModel):
+class TestModelConnectionMixin(object):
+    """
+    Use it in first class for all RedisModel created for tests, or define
+    the following settings in each
+    """
+    CONNECTION_SETTINGS = TEST_CONNECTION_SETTINGS
+
+
+class Bike(TestModelConnectionMixin, model.RedisModel):
     name = fields.StringField(indexable=True)
     wheels = fields.StringField(default=2)
     passengers = fields.StringField(default=1, cacheable=False)
@@ -20,7 +28,7 @@ class MotorBike(Bike):
     power = fields.StringField()
 
 
-class Boat(model.RedisModel):
+class Boat(TestModelConnectionMixin, model.RedisModel):
     """
     Use also HashableField.
     """
@@ -321,7 +329,7 @@ class MetaRedisProxyTest(LimpydBaseTest):
 
 class PostCommandTest(LimpydBaseTest):
 
-    class MyModel(model.RedisModel):
+    class MyModel(TestModelConnectionMixin, model.RedisModel):
         name = fields.HashableField()
         last_modification_date = fields.HashableField()
 
@@ -389,13 +397,13 @@ class InheritanceTest(LimpydBaseTest):
 
 class PKFieldTest(LimpydBaseTest):
 
-    class AutoPkModel(model.RedisModel):
+    class AutoPkModel(TestModelConnectionMixin, model.RedisModel):
         name = fields.StringField(indexable=True)
 
     class RedefinedAutoPkModel(AutoPkModel):
         id = fields.AutoPKField()
 
-    class NotAutoPkModel(model.RedisModel):
+    class NotAutoPkModel(TestModelConnectionMixin, model.RedisModel):
         pk = fields.PKField()
         name = fields.StringField(indexable=True)
 
@@ -519,6 +527,31 @@ class PKFieldTest(LimpydBaseTest):
         # collection via pk or id
         self.assertEqual(self.RedefinedNotAutoPkField.collection(pk=1), set(['1', ]))
         self.assertEqual(self.RedefinedNotAutoPkField.collection(id=2), set(['2', ]))
+
+
+class ConnectionTest(LimpydBaseTest):
+
+    def test_connection_is_the_one_defined(self):
+        defined_config = TEST_CONNECTION_SETTINGS
+        current_config = self.connection.connection_pool.connection_kwargs
+        bike = Bike(name="rosalie", wheels=4)
+        obj_config = bike.connection.connection_pool.connection_kwargs
+        class_config = Bike.CONNECTION_SETTINGS
+        for arg in ('host', 'port', 'db'):
+            self.assertEqual(defined_config[arg], current_config[arg])
+            self.assertEqual(defined_config[arg], obj_config[arg])
+            self.assertEqual(defined_config[arg], class_config[arg])
+
+    def test_connection_should_be_shared(self):
+        first_connected = self.connection.info()['connected_clients']
+        bike = Bike(name="rosalie", wheels=4)
+        self.assertEqual(first_connected, self.connection.info()['connected_clients'])
+        Bike.collection(name="rosalie")
+        self.assertEqual(first_connected, self.connection.info()['connected_clients'])
+        bike.name.set("randonneuse")
+        self.assertEqual(first_connected, self.connection.info()['connected_clients'])
+        boat = Boat(name="Pen Duick I", length=15.1, launched=1898)
+        self.assertEqual(bike.connection, boat.connection)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Settings for a connection are now a dict
- Default are localhost:6379 db=0
- Connection settings can be set per model
- Connections are now really shared
- Save a _model attribute on each field and a field always use the
  connection of the model class (via _model)
- Remove the _parent_class attribute now that we have the _model, the
  _parent_class is replaced when needed by _model._name (which is the
  lowered class name)
