### PR TITLE
Enhance the __getattr__ method

### DIFF
--- a/limpyd/fields.py
+++ b/limpyd/fields.py
@@ -42,7 +42,9 @@ class RedisProxyCommand(object):
         """
         Return the function in redis when not found in the abstractmodel.
         """
-        return lambda *args, **kwargs: self._traverse_command(name, *args, **kwargs)
+        if name in self.available_commands:
+            return lambda *args, **kwargs: self._traverse_command(name, *args, **kwargs)
+        return self.__getattribute__(name)
 
     @memoize_command()
     def _traverse_command(self, name, *args, **kwargs):
@@ -218,7 +220,7 @@ class IndexableField(RedisField):
         self.indexable = kwargs.get("indexable", False)
         self.unique = kwargs.get("unique", False)
         if self.unique:
-            if "default" in dir(self):  # do not use hasattr, as it will call getattr
+            if hasattr(self, "default"):
                 raise ImplementationError('Cannot set "default" and "unique" together!')
             self.indexable = True
 

--- a/limpyd/model.py
+++ b/limpyd/model.py
@@ -181,6 +181,8 @@ class RedisModel(RedisProxyCommand):
         return self._cache[self.name]
 
     def get_pk(self):
+        if not hasattr(self, '_pk'):
+            raise DoesNotExist("The current object doesn't exists anymore")
         if not self._pk:
             self.pk.set(None)
             # Default must be setted only at first initialization
@@ -193,7 +195,7 @@ class RedisModel(RedisProxyCommand):
         """
         for field_name in self._fields:
             field = getattr(self, field_name)
-            if "default" in dir(field):
+            if hasattr(field, "default"):
                 setter = getattr(field, field.proxy_setter)
                 getter = getattr(field, field.proxy_getter)
                 has_value = getter()

--- a/tests/model.py
+++ b/tests/model.py
@@ -662,9 +662,10 @@ class DeleteTest(LimpydBaseTest):
         # If we delete the train1, only 6 key must remain
         train1.delete()
         self.assertEqual(len(self.connection.keys()), 6)
-        self.assertEqual(train1.name.hget(), None)
-        self.assertEqual(train1.kind.get(), None)
-        self.assertEqual(train1.wagons.hget(), None)
+        with self.assertRaises(DoesNotExist):
+            train1.name.hget()
+        with self.assertRaises(DoesNotExist):
+            train1.kind.get()
         self.assertFalse(Train.exists(name="Occitan"))
         self.assertTrue(Train.exists(name="Teoz"))
         self.assertEqual(train2.name.hget(), 'Teoz')


### PR DESCRIPTION
It now permits the use of hasattr and getattr functions.
By doing this, the bahaviour of the "get_pk" method of a deleted
instance hs changed, and now raise a DoesNotExist exception, so the
"test_model_delete" test is updated to reflect this update.
