### PR TITLE
Add a "log_debug_to_stderr" method in tests.utils

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,8 @@ from limpyd.utils import make_key, unique_key
 
 from logging import getLogger, DEBUG, StreamHandler
 
-class log_debug_to_stderr():
+
+def log_debug_to_stderr():
     log = getLogger('limpyd')
     log.setLevel(DEBUG)
     log.addHandler(StreamHandler())


### PR DESCRIPTION
While writing tests and playing with them, it can be useful to see
output of the logger in stderr.
It's as easy to call this method one time.
It's a simple helper.
