### PR TITLE
Enhance the field copy system.

### DIFF
--- a/limpyd/fields.py
+++ b/limpyd/fields.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 
 from logging import getLogger
+from copy import copy
 from redis.exceptions import RedisError
 
 from limpyd import redis_connect, DEFAULT_CONNECTION_SETTINGS
@@ -135,6 +136,11 @@ class RedisField(RedisProxyCommand):
 
     proxy_setter = None
     unique = False
+    _copy_conf = {
+        'args': [],
+        'kwargs': ['cacheable', 'default'],
+        'attrs': ['name', '_instance', '_model']
+    }
 
     def __init__(self, *args, **kwargs):
         self.indexable = False
@@ -199,12 +205,40 @@ class RedisField(RedisProxyCommand):
         In the RedisModel metaclass and constructor, we need to copy the fields
         to new ones. It can be done via the copy function of the copy module.
         This __copy__ method handles the copy by creating a new field with same
-        attributes, without ignoring private attributes
+        attributes, without ignoring private attributes.
+        Configuration of args and kwargs to pass to the constructor, and
+        attributes to copy is done in the _copy_conf attribute of the class, a
+        dict with 3 entries:
+          - args: list of attributes names to pass as *args to the constructor
+          - kwargs: list of attributes names to pass as **kwargs to the
+                    constructor. If a tuple is used instead of a simple string
+                    in the list, its first entry will be the kwarg name, and
+                    the second the name of the attribute to copy
+          - attrs: list of attributes names to copy (with "=") from the old
+                   object to the new one
         """
-        new_copy = self.__class__(**self.__dict__)
-        for attr_name in ('name', '_instance', '_model'):
+        # prepare unnamed arguments
+        args = [getattr(self, arg) for arg in self._copy_conf['args']]
+
+        # prepare named arguments
+        kwargs = {}
+        for arg in self._copy_conf['kwargs']:
+            # if arg is a tuple, the first entry will be the named kwargs, and
+            # the second will be the name of the attribute to copy
+            name = arg
+            if isinstance(arg, tuple):
+                name, arg = arg
+            if hasattr(self, arg):
+                kwargs[name] = getattr(self, arg)
+
+        # create the new instance
+        new_copy = self.__class__(*args, **kwargs)
+
+        # then copy attributes
+        for attr_name in self._copy_conf['attrs']:
             if hasattr(self, attr_name):
                 setattr(new_copy, attr_name, getattr(self, attr_name))
+
         return new_copy
 
     def make_key(self, *args):
@@ -253,6 +287,7 @@ class RedisField(RedisProxyCommand):
         else:
             return self.connection.exists(key)
 
+
 class IndexableField(RedisField):
     """
     Base field for the indexable fields.
@@ -260,6 +295,8 @@ class IndexableField(RedisField):
     Store data in index at save.
     Retrieve instances from these indexes.
     """
+    _copy_conf = copy(RedisField._copy_conf)
+    _copy_conf['kwargs'] += ['indexable', 'unique']
 
     def __init__(self, *args, **kwargs):
         super(IndexableField, self).__init__(*args, **kwargs)
@@ -686,14 +723,8 @@ class PKField(RedisField):
     _auto_added = False  # True only if automatically added by limpyd
     _set = False  # True when set for the first (and unique) time
 
-    def __copy__(self):
-        """
-        Overload the behaviour of the copy method to copy specific fields
-        """
-        new_copy = super(PKField, self).__copy__()
-        new_copy._auto_increment = self._auto_increment
-        new_copy._auto_added = self._auto_added
-        return new_copy
+    _copy_conf = copy(RedisField._copy_conf)
+    _copy_conf['attrs'] += ['_auto_increment', '_auto_added']
 
     def normalize(self, value):
         """


### PR DESCRIPTION
Many times, RedisField objects are copied, using the copy module.
The way the __copy__ method did things was to create a new object,
and copy other attributes.
In a subclass, to copy new attributes, it was as easy as to define a new
__copy__ method, call super, and do more stuff.
But there was a big problem with the call to the constructor: we passed
the whole self.__dict__ dict, whatever the real signature was. First, we
pass some not attended arguments, and second, this didn't work if the
signature is different.
So all the __copy__ method is now rewritten to call the constructor, and
copy attributes, all using a _copy_conf attribute on the class.
This _copy_conf attribute is a dict with 3 entries:
    - args: list of attributes names to pass as _args to the constructor
    - kwargs: list of attributes names to pass as *_kwargs to the
              constructor. If a tuple is used instead of a simple string
              in the list, its first entry will be the kwarg name, and
              the second the name of the attribute to copy
    - attrs: list of attributes names to copy (with "=") from the old
             object to the new one

The main goal of this internal change, is to allow subfield with different
signatures than RedisField
