### PR TITLE
Include only the "limpyd" package in setup.py (no tests)

### DIFF
--- a/limpyd/__init__.py
+++ b/limpyd/__init__.py
@@ -2,7 +2,7 @@
 power and the control of the Redis API, in a limpid way, with just as
 abstraction as needed."""
 
-VERSION = (0, 1, 0)
+VERSION = (0, 1, 1)
 
 __author__ = 'Yohan Boniface'
 __contact__ = "yb@enix.org"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import codecs
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 import limpyd
 
@@ -18,7 +18,7 @@ setup(
     keywords = "redis",
     url = limpyd.__homepage__,
     download_url = "https://github.com/yohanboniface/redis-limpyd/tags",
-    packages = find_packages(),
+    packages = ['limpyd'],
     include_package_data=True,
     install_requires=["redis", ],
     platforms=["any"],


### PR DESCRIPTION
We do not need the tests in the final installed build, so, as we only need the "limpyd" package, I removed the use of find_packages, which is really useful only for big projects (http://pythonhosted.org/distribute/setuptools.html#using-find-packages)

PS: I tested the build locally ;)
