### PR TITLE
[contrib] Add multi-indexes composition + DateTimeIndex

### DIFF
--- a/doc/contrib.rst
+++ b/doc/contrib.rst
@@ -909,6 +909,17 @@ And to have the same with the time parts, simply compose a new index with the la
     ...     TimeIndexParts.configure(transform=lambda value: value[11:]),  # pass only time
     ... ], name='DateTimeIndex')
 
+For simplest cases let's make a ``SimpleDateTimeIndex`` that doesn't contains parts:
+
+.. code:: python
+
+    >>> SimpleDateTimeIndex = MultiIndexes.compose([
+    ...     TextRangeIndex.configure(key='full', name='FullDateTimeRangeIndex'),
+    ...     DateRangeIndex.configure(prefix='date'),
+    ...     TimeRangeIndex.configure(prefix='time', transform=lambda value: value[11:])  # pass only time
+    ... ], name='SimpleDateTimeIndex', transform=lambda value: value[:19])  # restrict on date+time
+
+
 And we're done!
 
 .. _Redis: http://redis.io

--- a/limpyd/collection.py
+++ b/limpyd/collection.py
@@ -245,18 +245,18 @@ class CollectionManager(object):
                 final_sets.add(set_)
             elif isinstance(set_, ParsedFilter):
 
-                index_key, key_type, is_tmp = set_.index.get_filtered_key(
-                    set_.suffix,
-                    accepted_key_types=self._accepted_key_types,
-                    *(set_.extra_field_parts + [set_.value])
-                )
-                if key_type not in self._accepted_key_types:
-                    raise ValueError('The index key returned by the index %s is not valid' % (
-                        set_.index.__class__.__name__
-                    ))
-                final_sets.add(index_key)
-                if is_tmp:
-                    tmp_keys.add(index_key)
+                for index_key, key_type, is_tmp in set_.index.get_filtered_keys(
+                            set_.suffix,
+                            accepted_key_types=self._accepted_key_types,
+                            *(set_.extra_field_parts + [set_.value])
+                        ):
+                    if key_type not in self._accepted_key_types:
+                        raise ValueError('The index key returned by the index %s is not valid' % (
+                            set_.index.__class__.__name__
+                        ))
+                    final_sets.add(index_key)
+                    if is_tmp:
+                        tmp_keys.add(index_key)
             else:
                 raise ValueError('Invalid filter type')
 

--- a/limpyd/contrib/indexes.py
+++ b/limpyd/contrib/indexes.py
@@ -250,3 +250,10 @@ DateTimeIndex = MultiIndexes.compose([
     DateSimpleTimeIndex,
     TimeIndexParts.configure(transform=lambda value: value[11:]),
 ], name='DateTimeIndex')
+
+# And a simple datetime index without parts
+SimpleDateTimeIndex = MultiIndexes.compose([
+    TextRangeIndex.configure(key='full', name='FullDateTimeRangeIndex'),
+    DateRangeIndex.configure(prefix='date'),
+    TimeRangeIndex.configure(prefix='time', transform=lambda value: value[11:])  # pass only time
+], name='SimpleDateTimeIndex', transform=lambda value: value[:19])

--- a/limpyd/contrib/indexes.py
+++ b/limpyd/contrib/indexes.py
@@ -1,0 +1,210 @@
+# -*- coding:utf-8 -*-
+from __future__ import unicode_literals
+
+from limpyd.indexes import BaseIndex
+from limpyd.utils import cached_property
+
+
+class MultiIndexes(BaseIndex):
+    """An index that is a proxy to many ones
+
+    This must not be used directly as a class, but a new index class must be
+    created by using the ``create`` class method
+
+    Attributes
+    ----------
+    index_classes: list
+        The index classes composing this multi-indexes class
+    key: str
+        A key to avoid collision with another index/multi-index
+        that will be passed to a field.
+
+    Examples
+    --------
+
+        >>> multi_index = MultiIndexes.compose([MyIndex, MyOtherIndex])
+        >>> class MyModel(RedisModel):
+        ...     field = StringField(indexes=[multi_index])
+
+    """
+    index_classes = []
+
+    @classmethod
+    def compose(cls, index_classes, key=None, transform=None, name=None):
+        """Create a new class with the given index classes
+
+        Parameters
+        -----------
+        index_classes: list
+            The list of index classes to be used in the multi-index class to create
+        name: str
+            The name of the new multi-index class. If not set, it will be the same
+            as the current class
+        key: str
+            A key to augment the default key of each index, to avoid collision.
+        transform: callable
+            None by default, can be set to a function that will transform the value to be indexed.
+            This callable can accept one (`value`) or two (`self`, `value`) arguments
+
+        """
+
+        attrs = {}
+        if index_classes:
+            attrs['index_classes'] = index_classes
+
+        klass = type(str(name or cls.__name__), (cls, ), attrs)
+
+        # let the ``configure`` method manage some fields
+        configure_attrs = {}
+        if key is not None:
+            configure_attrs['key'] = key
+        if transform is not None:
+            configure_attrs['transform'] = transform
+
+        if configure_attrs:
+            klass = klass.configure(**configure_attrs)
+
+        return klass
+
+    @cached_property
+    def _indexes(self):
+        """Instantiate the indexes only when asked
+
+        Returns
+        -------
+        list
+            A list of all indexes, tied to the field.
+
+        """
+        return [index_class(field=self.field) for index_class in self.index_classes]
+
+    def can_handle_suffix(self, suffix):
+        """Tell if one of the managed indexes  can be used for the given filter prefix
+
+        For parameters, see BaseIndex.can_handle_suffix
+
+        """
+        for index in self._indexes:
+            if index.can_handle_suffix(suffix):
+                return True
+
+        return False
+
+    def _reset_cache(self):
+        """Reset attributes used to potentially rollback the indexes
+
+        For the parameters, seen BaseIndex._reset_cache
+
+        """
+        for index in self._indexes:
+            index._reset_cache()
+
+    def _rollback(self):
+        """Restore the index in its previous state
+
+        For the parameters, seen BaseIndex._rollback
+
+        """
+        for index in self._indexes:
+            index._rollback()
+
+    def get_unique_index(self):
+        """Returns the first index handling uniqueness
+
+        Returns
+        -------
+        BaseIndex
+            The first index capable of handling uniqueness
+
+        Raises
+        ------
+        IndexError
+            If not index is capable of handling uniqueness
+
+        """
+        return [index for index in self._indexes if index.handle_uniqueness][0]
+
+    @property
+    def handle_uniqueness(self):
+        """Tell if at least one of the indexes can handle uniqueness
+
+        Returns
+        -------
+        bool
+            ``True`` if this multi-index can handle uniqueness.
+
+        """
+        try:
+            self.get_unique_index()
+        except IndexError:
+            return False
+        else:
+            return True
+
+    def prepare_args(self, args, transform=True):
+        """Prepare args to be used by a sub-index
+
+        Parameters
+        ----------
+        args: list
+            The while list of arguments passed to add, check_uniqueness, get_filtered_keys...
+        transform: bool
+            If ``True``, the last entry in `args`, ie the value, will be transformed.
+            Else it will be kept as is.
+
+        """
+        updated_args = list(args)
+        if transform:
+            updated_args[-1] = self.transform_value(updated_args[-1])
+        if self.key:
+            updated_args.insert(-1, self.key)
+
+        return updated_args
+
+    def check_uniqueness(self, *args):
+        """For a unique index, check if the given args are not used twice
+
+        For the parameters, seen BaseIndex.check_uniqueness
+
+        """
+        self.get_unique_index().check_uniqueness(*self.prepare_args(args, transform=False))
+
+    def add(self, *args, **kwargs):
+        """Add the instance tied to the field to all the indexes
+
+        For the parameters, seen BaseIndex.add
+
+        """
+
+        check_uniqueness = kwargs.pop('check_uniqueness', False)
+        args = self.prepare_args(args)
+
+        for index in self._indexes:
+            index.add(*args, check_uniqueness=check_uniqueness and index.handle_uniqueness, **kwargs)
+            if check_uniqueness and index.handle_uniqueness:
+                check_uniqueness = False
+
+    def remove(self, *args):
+        """Remove the instance tied to the field from all the indexes
+
+        For the parameters, seen BaseIndex.remove
+
+        """
+
+        args = self.prepare_args(args)
+
+        for index in self._indexes:
+            index.remove(*args)
+
+    def get_filtered_keys(self, suffix, *args, **kwargs):
+        """Returns the index keys to be used by the collection for the given args
+
+        For the parameters, see BaseIndex.get_filtered_keys
+
+        """
+
+        args = self.prepare_args(args, transform=False)
+
+        for index in self._indexes:
+            if index.can_handle_suffix(suffix):
+                return index.get_filtered_keys(suffix, *args, **kwargs)

--- a/limpyd/indexes.py
+++ b/limpyd/indexes.py
@@ -1,6 +1,8 @@
 # -*- coding:utf-8 -*-
 from __future__ import unicode_literals
-from future.builtins import object, str
+from future.builtins import str, object
+from future.utils import PY3
+from past.builtins import str as oldstr
 
 from logging import getLogger
 
@@ -23,6 +25,14 @@ class BaseIndex(object):
     handle_uniqueness: bool
         If ``True``, the index is able to check for uniqueness. When many index are used, only
         the first with this flag set to ``True`` have to do the work.
+    prefix: str
+        If defined, will be used as a prefix to the suffix in the collection
+        For example, with a prefix "foo" and the suffix "eq": "myfield__foo__eq="
+        May be defined at the class level for a subclass, or by calling the ``configure``
+        class method
+    transform: callable
+        None by default, can be set to a function that will transform the value to be indexed.
+        This callable can accept one (`value`) or two (`self`, `value`) arguments
 
     Parameters
     -----------
@@ -33,11 +43,72 @@ class BaseIndex(object):
 
     handled_suffixes = set()
     handle_uniqueness = False
+    key = None
+    prefix = None
+    transform = None
 
     def __init__(self, field):
         """Attach the index to the given field and prepare the internal cache"""
         self.field = field
         self._reset_cache()
+
+    @classmethod
+    def configure(cls, **kwargs):
+        """Create a new index class with the given info
+
+        This allow to avoid creating a new class when only few changes are
+        to be made
+
+        Parameters
+        ----------
+        kwargs: dict
+            prefix: str
+                The string part to use in the collection, before the normal suffix.
+                For example `foo` to filter on `myfiled__foo__eq=`
+                This prefix will also be used by the indexes to store the data at
+                a different place than the same index without prefix.
+            transform: callable
+                A function that will transform the value to be used as the reference
+                for the index, before the call to `normalize_value`.
+                If can be extraction of a date, or any computation.
+                The filter in the collection will then have to use a transformed value,
+                for example `birth_date__year=1976` if the transform take a date and
+                transform it to a year.
+            handle_uniqueness: bool
+                To make the index handle or not the uniqueness
+            key: str
+                To override the key used by the index. Two indexes for the same field of
+                the same type must not have the same key or data will be saved at the same place.
+                Note that the default key is None for `EqualIndex`, `text-range` for
+                `TextRangeIndex` and `number-range` for `NumberRangeIndex`
+            name: str
+                The name of the new multi-index class. If not set, it will be the same
+                as the current class
+
+        Returns
+        -------
+        type
+            A new class based on `cls`, with the new attributes set
+
+        """
+
+        attrs = {}
+        for key in ('prefix', 'handle_uniqueness', 'key'):
+            if key in kwargs:
+                attrs[key] = kwargs.pop(key)
+
+        if 'transform' in kwargs:
+            attrs['transform'] = staticmethod(kwargs.pop('transform'))
+
+        name = kwargs.pop('name', None)
+
+        if kwargs:
+            raise TypeError('%s.configure only accepts these named arguments: %s' % (
+                cls.__name__,
+                ', '.join(('prefix', 'transform', 'handle_uniqueness', 'key', 'name')),
+            ))
+
+        return type((str if PY3 else oldstr)(name or cls.__name__), (cls, ), attrs)
 
     def can_handle_suffix(self, suffix):
         """Tell if the current index can be used for the given filter suffix
@@ -53,18 +124,25 @@ class BaseIndex(object):
             ``True`` if the index can handle this suffix, ``False`` otherwise.
 
         """
-        return suffix in self.handled_suffixes
+        try:
+            return self.remove_prefix(suffix) in self.handled_suffixes
+        except IndexError:
+            return False
 
-    def normalize_value(self, value):
+    def normalize_value(self, value, transform=True):
         """Prepare the given value to be stored in the index
 
-        It calls the ``from_python`` method of the field, then cast the result
+        It first calls ``transform_value`` if ``transform`` is ``True``, then
+        calls the ``from_python`` method of the field, then cast the result
         to a str.
 
         Parameters
         ----------
         value: any
             The value to normalize
+        transform: bool
+            If ``True`` (the default), the value will be passed to ``transform_value``.
+            The returned value will then be used.
 
         Returns
         -------
@@ -72,7 +150,59 @@ class BaseIndex(object):
             The value, normalized
 
         """
+        if transform:
+            value = self.transform_value(value)
         return str(self.field.from_python(value))
+
+    def transform_value(self, value):
+        """Convert the value to be stored.
+
+        This does nothing by default but subclasses can change this.
+        Then the index will be able to filter on the transformed value.
+        For example if the transform capitalizes some text, the filter
+        would be ``myfield__capitalized__eq='FOO'``
+
+        """
+        if not self.transform:
+            return value
+
+        try:
+            # we store a staticmethod but we accept a method taking `self` and `value`
+            return self.transform(self, value)
+        except TypeError as e:
+            if 'argument' in str(e):  # try to limit only to arguments error
+                return self.transform(value)
+
+    @classmethod
+    def remove_prefix(cls, suffix):
+        """"Remove the class prefix from the suffix
+
+        The collection pass the full suffix used in the filters to the index.
+        But to know if it is valid, we have to remove the prefix to get the
+        real suffix, for example to check if the suffix is handled by the index.
+
+        Parameters
+        -----------
+        suffix: str
+            The full suffix to split
+
+        Returns
+        -------
+        str or None
+            The suffix without the prefix. None if the resting suffix is ''
+
+        Raises
+        ------
+        IndexError:
+            If the suffix doesn't contain the prefix
+
+        """
+
+        if not cls.prefix:
+            return suffix
+        if cls.prefix == suffix:
+            return None
+        return (suffix or '').split(cls.prefix + '__')[1] or None
 
     @property
     def connection(self):
@@ -247,41 +377,10 @@ class BaseIndex(object):
 
 
 class EqualIndex(BaseIndex):
-    """Default simple equal index.
-
-    It can be overridden to create transformative index by overriding:
-    - handled_suffixes
-    - index_key_name
-    - transform_normalized_value_for_storage
-
-    Examples
-    --------
-
-    To create an 'reverse' index where the user could do `name__reverse_eq='oof'`
-    to get an object with the value of 'foo', use this index:
-
-    >>> class ReverseEqualIndex(EqualIndex):
-    ...     handled_suffixes = {'reverse_eq'}
-    ...     index_key_name = 'reverse-equal'
-    ...
-    ...     def transform_normalized_value_for_storage(self, value):
-    ...         return value[::-1]
-
-
-    """
+    """Default simple equal index."""
 
     handled_suffixes = {None, 'eq'}
     handle_uniqueness = True
-    index_key_name = None
-
-    def transform_normalized_value_for_storage(self, value):
-        """Convert the value to be used in the storage key.
-
-        This does nothing in this equal index but may be changed for a
-        transformative index based on this one.
-
-        """
-        return value
 
     def get_filtered_keys(self, suffix, *args, **kwargs):
         """Return the set used by the index for the given "value" (`args`)
@@ -297,6 +396,7 @@ class EqualIndex(BaseIndex):
                 '%s can only return keys of type "set"' % self.__class__.__name__
             )
 
+        # do not transform because we already have the value we want to look for
         return [(self.get_storage_key(transform_value=False, *args), 'set', False)]
 
     def get_storage_key(self, *args, **kwargs):
@@ -311,8 +411,8 @@ class EqualIndex(BaseIndex):
         -----------
         kwargs: dict
             transform_value: bool
-                Default to ``True``. When ``True``, ``transform_normalized_value_for_storage``
-                is called with the normalized value, else it is used directly.
+                Default to ``True``. Tell the call to ``normalize_value`` to transform
+                the value or not
         args: tuple
             All the "values" to take into account to get the storage key.
 
@@ -331,12 +431,13 @@ class EqualIndex(BaseIndex):
             self.field.name,
         ] + args
 
-        if self.index_key_name:
-            parts.append(self.index_key_name)
+        if self.prefix:
+            parts.append(self.prefix)
 
-        normalized_value = self.normalize_value(value)
-        if kwargs.get('transform_value', True):
-            normalized_value = self.transform_normalized_value_for_storage(normalized_value)
+        if self.key:
+            parts.append(self.key)
+
+        normalized_value = self.normalize_value(value, transform=kwargs.get('transform_value', True))
 
         parts.append(normalized_value)
 
@@ -408,7 +509,6 @@ class BaseRangeIndex(BaseIndex):
     """Base of indexes using sorted-set to do range filtering (lt, gte...)"""
 
     handle_uniqueness = True
-    index_key_name = NotImplemented
     lua_filter_script = NotImplemented
 
     def get_storage_key(self, *args):
@@ -438,11 +538,33 @@ class BaseRangeIndex(BaseIndex):
         parts = [
             self.model._name,
             self.field.name,
-        ] + args + [
-            self.index_key_name,
-        ]
+        ] + args
+
+        if self.prefix:
+            parts.append(self.prefix)
+
+        if self.key:
+            parts.append(self.key)
 
         return self.field.make_key(*parts)
+
+    def prepare_value_for_storage(self, value, pk):
+        """Prepare the value to be stored in the zset
+
+        Parameters
+        ----------
+        value: any
+            The value, to normalize, to use
+        pk: any
+            The pk, that will be stringified
+
+        Returns
+        -------
+        str
+            The string ready to use as member of the sorted set.
+
+        """
+        return self.normalize_value(value)
 
     def check_uniqueness(self, *args, **kwargs):
         """Check if the given "value" (via `args`) is unique or not.
@@ -489,7 +611,7 @@ class BaseRangeIndex(BaseIndex):
 
         pk = self.instance.pk.get()
         logger.debug("adding %s to index %s" % (pk, key))
-        self.store(key, pk, value)
+        self.store(key, pk, self.prepare_value_for_storage(value, pk))
         self._indexed_values.add(tuple(args))
 
     def store(self, key, pk, value):
@@ -526,7 +648,7 @@ class BaseRangeIndex(BaseIndex):
 
         pk = self.instance.pk.get()
         logger.debug("removing %s from index %s" % (pk, key))
-        self.unstore(key, pk, value)
+        self.unstore(key, pk, self.prepare_value_for_storage(value, pk))
         self._deindexed_values.add(tuple(args))
 
     def unstore(self, key, pk, value):
@@ -625,13 +747,15 @@ class BaseRangeIndex(BaseIndex):
         key = self.get_storage_key(*args)
         tmp_key = unique_key(self.connection)
         key_type = 'set' if not accepted_key_types or 'set' in accepted_key_types else 'zset'
-        value = self.normalize_value(list(args)[-1])
+        value = self.normalize_value(list(args)[-1], transform=False)
+
+        real_suffix = self.remove_prefix(suffix)
 
         if use_lua:
-            start, end, exclude = self.get_boundaries(suffix, value)
+            start, end, exclude = self.get_boundaries(real_suffix, value)
             self.call_script(key, tmp_key, key_type, start, end, exclude)
         else:
-            pks = self.get_pks_for_filter(key, suffix, value)
+            pks = self.get_pks_for_filter(key, real_suffix, value)
             if pks:
                 if key_type == 'set':
                     self.connection.sadd(tmp_key, *pks)
@@ -677,8 +801,8 @@ class TextRangeIndex(BaseRangeIndex):
     """
 
     handled_suffixes = {None, 'eq', 'gt', 'gte', 'lt', 'lte', 'startswith'}
-    index_key_name = 'text-range'
-    separator = u':%s-SEPARATOR:' % index_key_name.upper()
+    key = 'text-range'
+    separator = u':%s-SEPARATOR:' % key.upper()
 
     lua_filter_script = {
         # we extract members of the sorted-set via zrangebylex
@@ -754,24 +878,15 @@ class TextRangeIndex(BaseRangeIndex):
                     )
                 )
 
-    def _prepare_value_for_storage(self, value, pk):
-        """Prepare the value to be stored in the zset: value and pk separated
+    def prepare_value_for_storage(self, value, pk):
+        """Prepare the value to be stored in the zset
 
-        Parameters
-        ----------
-        value: any
-            The value, to normalize, to use
-        pk: any
-            The pk, that will be stringified
+        We'll store the value and pk concatenated.
 
-        Returns
-        -------
-        str
-            The string ready to use as member of the sorted set.
-
+        For the parameters, see BaseRangeIndex.prepare_value_for_storage
         """
-        normalized_value = self.normalize_value(value)
-        return self.separator.join([normalized_value, str(pk)])
+        value = super(TextRangeIndex, self).prepare_value_for_storage(value, pk)
+        return self.separator.join([value, str(pk)])
 
     def _extract_value_from_storage(self, string):
         """Taking a string that was a member of the zset, extract the value and pk
@@ -802,7 +917,7 @@ class TextRangeIndex(BaseRangeIndex):
 
         """
 
-        self.connection.zadd(key, 0, self._prepare_value_for_storage(value, pk))
+        self.connection.zadd(key, 0, value)
 
     def unstore(self, key, pk, value):
         """Remove the value/pk from the sorted set index
@@ -810,7 +925,7 @@ class TextRangeIndex(BaseRangeIndex):
         For the parameters, see BaseRangeIndex.store
         """
 
-        self.connection.zrem(key, self._prepare_value_for_storage(value, pk))
+        self.connection.zrem(key, value)
 
     def get_boundaries(self, filter_type, value):
         """Compute the boundaries to pass to zrangebylex depending of the filter type
@@ -908,7 +1023,8 @@ class TextRangeIndex(BaseRangeIndex):
 class NumberRangeIndex(BaseRangeIndex):
 
     handled_suffixes = {None, 'eq', 'gt', 'gte', 'lt', 'lte'}
-    index_key_name = 'number-range'
+    key = 'number-range'
+    raise_if_not_float = False
 
     lua_filter_script = {
         # we extract members of the sorted-set via zrangebyscore
@@ -951,18 +1067,27 @@ class NumberRangeIndex(BaseRangeIndex):
         """
     }
 
-    def normalize_value(self, value):
+    def normalize_value(self, value, transform=True):
         """Prepare the given value to be stored in the index
 
         For the parameters, see BaseIndex.normalize_value
 
-        Here we force the value to be a float, and force it to be 0
-        if it cannot be casted.
+        Raises
+        ------
+        ValueError
+            If ``raise_if_not_float`` is True and the value cannot
+            be casted to a float.
 
         """
+        if transform:
+            value = self.transform_value(value)
         try:
             return float(value)
         except (ValueError, TypeError):
+            if self.raise_if_not_float:
+                raise ValueError('Invalid value %s for field %s.%s' % (
+                    value, self.model.__name__, self.field.name
+                ))
             return 0
 
     def store(self, key, pk, value):

--- a/tests/contrib/indexes.py
+++ b/tests/contrib/indexes.py
@@ -1,0 +1,168 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from limpyd import fields
+from limpyd.contrib.indexes import MultiIndexes
+from limpyd.exceptions import ImplementationError, UniquenessError
+from limpyd.indexes import BaseIndex, NumberRangeIndex, TextRangeIndex, EqualIndex
+
+from ..base import LimpydBaseTest
+from ..indexes import ReverseEqualIndex
+from ..model import TestRedisModel
+
+
+class MultiIndexesTestCase(LimpydBaseTest):
+
+    def test_can_be_created_with_many_indexes(self):
+        index_class = MultiIndexes.compose([TextRangeIndex, ReverseEqualIndex])
+
+        self.assertTrue(issubclass(index_class, BaseIndex))
+        self.assertTrue(issubclass(index_class, MultiIndexes))
+        self.assertEqual(index_class.__name__, 'MultiIndexes')
+        self.assertEqual(index_class.index_classes, [TextRangeIndex, ReverseEqualIndex])
+
+        index_class = MultiIndexes.compose([TextRangeIndex, NumberRangeIndex], name='MyMultiIndex')
+        self.assertEqual(index_class.__name__, 'MyMultiIndex')
+
+    def test_multi_index_with_only_one_should_behave_like_the_one(self):
+        index_class = MultiIndexes.compose([EqualIndex])
+
+        class MultiIndexOneIndexTestModel(TestRedisModel):
+            name = fields.StringField(indexable=True, indexes=[index_class], unique=True)
+
+        obj1 = MultiIndexOneIndexTestModel(name="foo")
+        pk1 = obj1.pk.get()
+        obj2 = MultiIndexOneIndexTestModel(name="bar")
+        pk2 = obj2.pk.get()
+
+        # test without suffix
+        self.assertSetEqual(
+            set(MultiIndexOneIndexTestModel.collection(name='foo')),
+            {pk1}
+        )
+
+        self.assertSetEqual(
+            set(MultiIndexOneIndexTestModel.collection(name='bar')),
+            {pk2}
+        )
+
+        self.assertSetEqual(
+            set(MultiIndexOneIndexTestModel.collection(name='foobar')),
+            set()
+        )
+
+        # test with suffix
+        self.assertSetEqual(
+            set(MultiIndexOneIndexTestModel.collection(name__eq='bar')),
+            {pk2}
+        )
+
+        # test invalid suffix
+        with self.assertRaises(ImplementationError):
+            MultiIndexOneIndexTestModel.collection(name__gte='bar')
+
+        # test uniqueness
+        with self.assertRaises(UniquenessError):
+            MultiIndexOneIndexTestModel(name="foo")
+
+    def test_chaining_should_work(self):
+
+        index_class = MultiIndexes.compose([
+            MultiIndexes.compose([
+                MultiIndexes.compose([
+                    MultiIndexes.compose([
+                        EqualIndex
+                    ])
+                ])
+            ])
+        ])
+
+        class ChainingIndexTestModel(TestRedisModel):
+            name = fields.StringField(indexable=True, indexes=[index_class], unique=True)
+
+        obj1 = ChainingIndexTestModel(name="foo")
+        pk1 = obj1.pk.get()
+        obj2 = ChainingIndexTestModel(name="bar")
+        pk2 = obj2.pk.get()
+
+        with self.assertRaises(UniquenessError):
+            ChainingIndexTestModel(name="foo")
+
+        self.assertEqual(
+            set(ChainingIndexTestModel.collection(name='foo')),
+            {pk1}
+        )
+
+    def test_filtering(self):
+
+        index_class = MultiIndexes.compose([
+            EqualIndex.configure(
+                prefix='first_letter',
+                transform=lambda v: v[0] if v else '',
+                handle_uniqueness=False
+            ),
+            EqualIndex
+        ])
+
+        class MultiIndexTestModel(TestRedisModel):
+            name = fields.StringField(indexable=True, indexes=[index_class], unique=True)
+
+        obj1 = MultiIndexTestModel(name="foo")
+        pk1 = obj1.pk.get()
+        obj2 = MultiIndexTestModel(name="bar")
+        pk2 = obj2.pk.get()
+
+        # we should not be able to add another with the same name
+        with self.assertRaises(UniquenessError):
+            MultiIndexTestModel(name="foo")
+
+        # but we can with the first letter being the same
+        # because our special index does not handle uniqueness
+        obj3 = MultiIndexTestModel(name='baz')
+        pk3 = obj3.pk.get()
+
+        # access without prefix: the simple should be used
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name='foo')),
+            {pk1}
+        )
+
+        # nothing with the first letter
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name='f')),
+            set()
+        )
+
+        # the same with `eq` suffix
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name__eq='foo')),
+            {pk1}
+        )
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name__eq='f')),
+            set()
+        )
+
+        # access with the suffix: the special index should be used
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name__first_letter='b')),
+            {pk2, pk3}
+        )
+        # also with the `eq` suffix
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name__first_letter__eq='b')),
+            {pk2, pk3}
+        )
+
+        # and nothing with the full name
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name__first_letter='bar')),
+            set()
+        )
+
+        # and it should work with both indexes
+        self.assertSetEqual(
+            set(MultiIndexTestModel.collection(name__first_letter='b', name='bar')),
+            {pk2}
+        )

--- a/tests/contrib/indexes.py
+++ b/tests/contrib/indexes.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from limpyd import fields
-from limpyd.contrib.indexes import MultiIndexes
+from limpyd.contrib.indexes import MultiIndexes, DateIndex, DateTimeIndex, TimeIndex
 from limpyd.exceptions import ImplementationError, UniquenessError
 from limpyd.indexes import BaseIndex, NumberRangeIndex, TextRangeIndex, EqualIndex
 
@@ -166,3 +166,208 @@ class MultiIndexesTestCase(LimpydBaseTest):
             set(MultiIndexTestModel.collection(name__first_letter='b', name='bar')),
             {pk2}
         )
+
+
+class DateTimeModelTest(TestRedisModel):
+    date = fields.InstanceHashField(indexable=True, indexes=[DateIndex])
+    unique_date = fields.InstanceHashField(indexable=True, indexes=[DateIndex], unique=True)
+    time = fields.InstanceHashField(indexable=True, indexes=[TimeIndex])
+    unique_time = fields.InstanceHashField(indexable=True, indexes=[TimeIndex], unique=True)
+    datetime = fields.InstanceHashField(indexable=True, indexes=[DateTimeIndex])
+    unique_datetime = fields.InstanceHashField(indexable=True, indexes=[DateTimeIndex], unique=True)
+
+
+class DateTimeIndexesTestCase(LimpydBaseTest):
+
+    def test_date_index(self):
+        obj1 = DateTimeModelTest(date='2015-12-16')
+        pk1 = obj1.pk.get()
+        obj2 = DateTimeModelTest(date='2014-09-07')
+        pk2 = obj2.pk.get()
+        obj3 = DateTimeModelTest(date='2015-06-12')
+        pk3 = obj3.pk.get()
+        obj4 = DateTimeModelTest(date='2016-12-31')
+        pk4 = obj4.pk.get()
+
+        # not unique so same date is ok
+        obj5 = DateTimeModelTest(date='2015-12-16')
+        pk5 = obj5.pk.get()
+
+        # EqualIndex
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date='2015-12-16')),
+            {pk1, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date__gte='2015-06-12')),
+            {pk1, pk3, pk4, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date__gt='2015')),
+            {pk1, pk3, pk4, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date__lt='2015-07')),
+            {pk2, pk3}
+        )
+
+        # year index
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date__year=2015)),
+            {pk1, pk3, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date__year__lt=2015)),
+            {pk2}
+        )
+
+        # month index
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date__month=12)),
+            {pk1, pk4, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(date__year=2015, date__month=12)),
+            {pk1, pk5}
+        )
+
+    def test_date_unique_index(self):
+        DateTimeModelTest(unique_date='2001-01-01')
+        # can add on same year (diff month/day)
+        DateTimeModelTest(unique_date='2001-02-02')
+        # can add on same month (diff year/day)
+        DateTimeModelTest(unique_date='2002-02-03')
+        # can add on same day (diff year/month)
+        DateTimeModelTest(unique_date='2003-03-03')
+
+        # cannot add on same date
+        with self.assertRaises(UniquenessError):
+            DateTimeModelTest(unique_date='2003-03-03')
+
+    def test_time_index(self):
+        # constructed the same as DateIndex so only test for transforms
+
+        obj1 = DateTimeModelTest(time='15:16:17')
+        pk1 = obj1.pk.get()
+        obj2 = DateTimeModelTest(time='05:06:07')
+        pk2 = obj2.pk.get()
+
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(time__hour='15')),
+            {pk1}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(time__minute='06')),
+            {pk2}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(time__second='17')),
+            {pk1}
+        )
+
+    def test_datetime_index(self):
+        obj1 = DateTimeModelTest(datetime='2015-12-16 15:16:17')
+        pk1 = obj1.pk.get()
+        obj2 = DateTimeModelTest(datetime='2014-09-07 05:06:07')
+        pk2 = obj2.pk.get()
+        obj3 = DateTimeModelTest(datetime='2015-06-12 15:16:17')
+        pk3 = obj3.pk.get()
+        obj4 = DateTimeModelTest(datetime='2016-12-31 05:06:07')
+        pk4 = obj4.pk.get()
+
+        # not unique so same date is ok
+        obj5 = DateTimeModelTest(datetime='2015-12-16 15:16:17')
+        pk5 = obj5.pk.get()
+
+        # check full date
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime='2015-12-16 15:16:17')),
+            {pk1, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__gte='2015-06-12 1')),
+            {pk1, pk3, pk4, pk5}
+        )
+
+        # check date
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__date='2015-12-16')),
+            {pk1, pk5}
+        )
+
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__date__lt='2015-07')),
+            {pk2, pk3}
+        )
+
+        # check year
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__year=2015)),
+            {pk1, pk3, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__year__lt=2015)),
+            {pk2}
+        )
+
+        # check time
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__time='15:16:17')),
+            {pk1, pk3, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__time__lt='15')),
+            {pk2, pk4}
+        )
+
+        # check hour
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__hour=15)),
+            {pk1, pk3, pk5}
+        )
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(datetime__hour__lt=15)),
+            {pk2, pk4}
+        )
+
+        # be crazy, check all for '2015-12-16 15:16:17'
+        # All are ended so it should work
+        self.assertSetEqual(
+            set(DateTimeModelTest.collection(
+                datetime='2015-12-16 15:16:17',
+                datetime__date='2015-12-16',
+                datetime__year=2015,
+                datetime__month=12,
+                datetime__day=16,
+                datetime__time='15:16:17',
+                datetime__hour=15,
+                datetime__minute=16,
+                datetime__second=17
+            )),
+            {pk1, pk5}
+        )
+
+    def test_datetime_unique_index(self):
+
+        DateTimeModelTest(unique_datetime='2001-01-01 01:01:01')
+        # can add on same year (diff month/day/hour/min/sec)
+        DateTimeModelTest(unique_datetime='2001-02-02 02:02:02')
+        # can add on same month (diff year/day/hour/min/sec)
+        DateTimeModelTest(unique_datetime='2002-02-03 03:03:03')
+        # can add on same day (diff year/month/hour/min/sec)
+        DateTimeModelTest(unique_datetime='2003-03-03 04:04:04')
+        # can add on same hour (diff year/month/day/min/sec)
+        DateTimeModelTest(unique_datetime='2004-04-04 04:05:05')
+        # can add on same minute (diff year/month/day/hour/sec)
+        DateTimeModelTest(unique_datetime='2005-05-05 05:05:06')
+        # can add on same second (diff year/month/day/hour/min)
+        DateTimeModelTest(unique_datetime='2006-06-06 06:06:06')
+
+        # can add on same date (diff time)
+        DateTimeModelTest(unique_datetime='2006-06-06 07:07:07')
+        # can add on same time (diff date)
+        DateTimeModelTest(unique_datetime='2007-07-07 07:07:07')
+
+        # but cannot add the same full datetime
+        with self.assertRaises(UniquenessError):
+            DateTimeModelTest(unique_datetime='2007-07-07 07:07:07')

--- a/tests/contrib/indexes.py
+++ b/tests/contrib/indexes.py
@@ -2,12 +2,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import unittest
+
 from limpyd import fields
 from limpyd.contrib.indexes import MultiIndexes, DateIndex, DateTimeIndex, TimeIndex
 from limpyd.exceptions import ImplementationError, UniquenessError
 from limpyd.indexes import BaseIndex, NumberRangeIndex, TextRangeIndex, EqualIndex
 
-from ..base import LimpydBaseTest
+from ..base import LimpydBaseTest, skip_if_no_zrangebylex
 from ..indexes import ReverseEqualIndex
 from ..model import TestRedisModel
 
@@ -177,6 +179,7 @@ class DateTimeModelTest(TestRedisModel):
     unique_datetime = fields.InstanceHashField(indexable=True, indexes=[DateTimeIndex], unique=True)
 
 
+@unittest.skipIf(*skip_if_no_zrangebylex)
 class DateTimeIndexesTestCase(LimpydBaseTest):
 
     def test_date_index(self):

--- a/tests/indexes.py
+++ b/tests/indexes.py
@@ -44,7 +44,7 @@ class EqualIndexKeyTestCase(unittest.TestCase):
         index = EqualIndex(Bike.get_field('name'))
         key = index.get_storage_key('rosalie')
         self.assertEqual(key, 'tests:bike:name:rosalie')
-        filter_key, key_type, is_tmp = index.get_filtered_key(None, 'rosalie')
+        filter_key, key_type, is_tmp = index.get_filtered_keys(None, 'rosalie')[0]
         self.assertEqual(filter_key, 'tests:bike:name:rosalie')
         self.assertEqual(key_type, 'set')
         self.assertFalse(is_tmp)
@@ -253,9 +253,9 @@ class TextRangeIndexTestCase(LimpydBaseTest):
         index = RangeIndexTestModel.get_field('name')._indexes[0]
 
         with self.assertRaises(ImplementationError):
-            index.get_filtered_key('gt', 'bar', accepted_key_types={'list'})
+            index.get_filtered_keys('gt', 'bar', accepted_key_types={'list'})
 
-        index_key, key_type, is_tmp = index.get_filtered_key('gt', 'bar', accepted_key_types={'set'})
+        index_key, key_type, is_tmp = index.get_filtered_keys('gt', 'bar', accepted_key_types={'set'})[0]
         self.assertEqual(self.connection.type(index_key), 'set')
         self.assertEqual(key_type, 'set')
         self.assertTrue(is_tmp)
@@ -267,7 +267,7 @@ class TextRangeIndexTestCase(LimpydBaseTest):
             self.pk5,  # qux gt bar
         })
 
-        index_key, key_type, is_tmp = index.get_filtered_key('lte', 'foo', accepted_key_types={'zset'})
+        index_key, key_type, is_tmp = index.get_filtered_keys('lte', 'foo', accepted_key_types={'zset'})[0]
         self.assertEqual(self.connection.type(index_key), 'zset')
         self.assertEqual(key_type, 'zset')
         self.assertTrue(is_tmp)
@@ -490,9 +490,9 @@ class NumberRangeIndexTestCase(LimpydBaseTest):
         index = RangeIndexTestModel.get_field('value')._indexes[0]
 
         with self.assertRaises(ImplementationError):
-            index.get_filtered_key('gt', -25, accepted_key_types={'list'})
+            index.get_filtered_keys('gt', -25, accepted_key_types={'list'})
 
-        index_key, key_type, is_tmp = index.get_filtered_key('gt', -25, accepted_key_types={'set'})
+        index_key, key_type, is_tmp = index.get_filtered_keys('gt', -25, accepted_key_types={'set'})[0]
         self.assertEqual(self.connection.type(index_key), 'set')
         self.assertEqual(key_type, 'set')
         self.assertTrue(is_tmp)
@@ -504,7 +504,7 @@ class NumberRangeIndexTestCase(LimpydBaseTest):
             self.pk5,  # 123 > -25
         })
 
-        index_key, key_type, is_tmp = index.get_filtered_key('lte', -15, accepted_key_types={'zset'})
+        index_key, key_type, is_tmp = index.get_filtered_keys('lte', -15, accepted_key_types={'zset'})[0]
         self.assertEqual(self.connection.type(index_key), 'zset')
         self.assertEqual(key_type, 'zset')
         self.assertTrue(is_tmp)


### PR DESCRIPTION
This PR depends on #101 

Multi-indexes allow to easily create complex indexes.

Here is a excerpt of `doc/contrib.rst` about the creation of the `DateTimeIndex`:

---

### DateTimeIndex

The `limpyd.contrib.indexes` module provides a `DateTimeIndex` (and other
friends). In this section we'll explain how it is constructed using only
the configure method of the normal indexes, and the compose method of
`MultiIndexes`

#### Goal

We'll store date+times in the format `YYYY-MM-SS HH:MM:SS`.

We want to be able to:
- filter on an exact date+time
- filter on ranges on the date+time
- filter on dates
- filter on times
- filter on dates parts (year, month, day)
- filter on times parts (hour, minute, second)

#### Date and time parts

Let's separate the date, and the time into `YYYY-MM-SS` and `HH:MM:SS`.

How to filter only on the year of a date: we want to extract the 4 first
characters, and filter it as number, using `NumberRangeIndex`:

Also, we don't want uniqueness on this index, and we want to prefix the
part to be able to filter with `myfield__year=2015`

So this part could be:

```python
>>> NumberRangeIndex.configure(prefix='year', transform=lambda value: value[:4], handle_uniqueness=False, name='YearIndex')
``````

Doing the same for the month and day, and composing a multi-indexes with
the three, we have:

```python
>>> DateIndexParts = MultiIndexes.compose([
...     NumberRangeIndex.configure(prefix='year', transform=lambda value: value[:4], handle_uniqueness=False, name='YearIndex'),
...     NumberRangeIndex.configure(prefix='month', transform=lambda value: value[5:7], handle_uniqueness=False, name='MonthIndex'),
...     NumberRangeIndex.configure(prefix='day', transform=lambda value: value[8:10], handle_uniqueness=False, name='DayIndex'),
... ], name='DateIndexParts')
`````

If we do the same for the time only (assuming a time field without
date), we have:

```python
>>> TimeIndexParts = MultiIndexes.compose([
...     NumberRangeIndex.configure(prefix='hour', transform=lambda value: value[0:2], handle_uniqueness=False, name='HourIndex'),
...     NumberRangeIndex.configure(prefix='minute', transform=lambda value: value[3:5], handle_uniqueness=False, name='MinuteIndex'),
...     NumberRangeIndex.configure(prefix='second', transform=lambda value: value[6:8], handle_uniqueness=False, name='SecondIndex'),
... ], name='TimeIndexParts')
````

#### Range indexes

If we want to filter not only on parts but also on the full date with a
`TextRangeIndex`, to be able to do `date_field__gte=2015`, we'll need
another index.

We don't want to use a prefix, but if we have another `TextRangeIndex` on
the field, we need a key:

```python
>>> DateRangeIndex = TextRangeIndex.configure(key='date', transform=lambda value: value[:10], name='DateRangeIndex')
```

The same for the time:

```python
>>> TimeRangeIndex = TextRangeIndex.configure(key='time', transform=lambda value: value[:8], name='TimeRangeIndex')
```

We don't keep theses two indexes apart from the `DateIndexParts` and
`TimeIndexParts` because we'll need them independently later to prefix
them when used together.

#### Full indexes

But if we want full indexes for dates and times, including the range
and the parts, we can easily compose them:

```python
>>> DateIndex = MultiIndexes.compose([DateRangeIndex, DateIndexParts], name='DateIndex')
>>> TimeIndex = MultiIndexes.compose([TimeRangeIndex, TimeIndexParts], name='TimeIndex')
```

Now that we have all that is needed for fields that manage date OR time,
we'll combine them. three things to take in consideration:

-   we'll have two `TextRangeIndex`, one for date one for time. So we need
    to explicitly prefix the filter, to be able to do `datetime_field__date__gte='2015'` and
    `datetime_field__time__gte='15:'`
-   we'll have to extract the date and time separately
-   we'll need a `TextRangeIndex` to filter on the whole datetime to be
    able do to `datetime_field__gte='2015-12-21 15:'`

In the first time, we'll want an index without the time parts, to allow
filtering and the three "ranges" (full, date, and time), but only on
date parts, not time parts. It can be useful if you know you won't have
to search on this.

So, to summarize, we need:

-   a `TextRangeIndex` for the full datetime
-   the `DateRangeIndex`, prefixed
-   the `DateIndexParts`
-   the `TimeRangeIndex`, prefixed

Which gives us:

```python
>>> DateSimpleTimeIndex = MultiIndexes.compose([
...     TextRangeIndex.configure(key='full', name='FullDateTimeRangeIndex'),
...     DateRangeIndex.configure(prefix='date'),
...     DateIndexParts,
...     TimeRangeIndex.configure(prefix='time', transform=lambda value: value[11:])  # pass only time
... ], name='DateSimpleTimeIndex', transform=lambda value: value[:19])  # restrict on date+time
```

And to have the same with the time parts, simply compose a new index
with the last one and the `TimeIndexPart`:

```python
>>> DateTimeIndex = MultiIndexes.compose([
...     DateSimpleTimeIndex,
...     TimeIndexParts.configure(transform=lambda value: value[11:]),  # pass only time
... ], name='DateTimeIndex')
```

And we're done !
