### PR TITLE
Correct and enhance collection slicing

### DIFF
--- a/limpyd/collection.py
+++ b/limpyd/collection.py
@@ -272,7 +272,7 @@ class CollectionManager(object):
                     if pk and not self._lazy_collection['sets']:
                         # we have a pk without other sets, and no
                         # needs to get values so we can simply return the pk
-                        collection = set([pk])
+                        collection = {pk}
                     else:
                         # we have nothing
                         collection = {}

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 from future.builtins import object
 
+from contextlib import contextmanager
 import sys
 import unittest
 
@@ -73,6 +74,75 @@ class LimpydBaseTest(unittest.TestCase):
         else:
             context.__exit__(*sys.exc_info())
 
+    if not hasattr(unittest.TestCase, 'subTest'):
+
+        @contextmanager
+        def subTest(self, msg=None, **params):
+            # support for the `subTest` command not available before python 3.4
+            # does nothing except running included test
+            yield
+
+    def assertSlicingIsCorrect(self, collection, check_data, check_only_length=False, limit=5):
+        """Test a wide range of slicing of the given collection, compared to a python list
+
+        Parameters
+        ----------
+        collection: Collection
+            The collection to test. Should not have been sliced yet
+        check_data: list
+            The python list containing the same values as the limpyd collection.
+            The result of slicing the collection will be compared to the result of slicing
+            this list
+        check_only_length: bool
+            Default to ``False``. When ``True``, only the length of the slicing of the collection
+            is comparedc to the slicing of the python list. To be used only when resulting content
+            cannot be assured (for unsorted collections)
+        limit: int
+            Default to ``5``, it's the boundary of the slicing ranges that will be tested.
+            ``5`` means will use all values from ``-5`` to ``5`` for each of the three parts
+            of the slicing.
+
+        """
+
+        # check we have the correct dataset
+        if check_only_length:
+            assert len(list(collection)) == len(check_data), 'Wrong dataset for this test'
+        else:
+            assert sorted(collection) == check_data, 'Wrong dataset for this test'
+
+        # do all the slices
+        total, optimized = 0, 0
+        for start in list(range(-limit, limit+1)) + [None]:
+            for stop in list(range(-limit, limit+1)) + [None]:
+                for step in range(-limit, limit+1):
+                    if not step:
+                        continue
+                    with self.subTest(Start=start, Stop=stop, step=step):
+                        total += 1
+
+                        result = collection[start:stop:step]
+                        expected = check_data[start:stop:step]
+
+                        if check_only_length:
+                            result = len(result)
+                            expected = len(expected)
+
+                        self.assertEqual(
+                            result,
+                            expected,
+                            'Unexpected result for `%s:%s:%s`' % (
+                                '' if start is None else start,
+                                '' if stop is None else stop,
+                                '' if step is None else step,
+                            )
+                        )
+                        if collection._optimized_slicing:
+                            optimized += 1
+
+        # ensure we have enough calls that are optimized
+        self.assertGreaterEqual(optimized * 100.0 / total, 60,
+                                    "Less than 60% slicing resulted in non-optimized calls")
+
 
 class _AssertNumCommandsContext(object):
     """
@@ -106,4 +176,3 @@ skip_if_no_zrangebylex = (
     not hasattr(Redis, 'zrangebylex'),
     'Redis-py %s does not support zrangebylex' % '.'.join(map(str, redispy_version))
 )
-

--- a/tests/collection.py
+++ b/tests/collection.py
@@ -35,9 +35,9 @@ class CollectionTest(CollectionBaseTest):
         Bike()
         self.assertEqual(set(Bike.collection()), set())
         bike1 = Bike(name="trotinette")
-        self.assertEqual(set(Bike.collection()), set([bike1._pk]))
+        self.assertEqual(set(Bike.collection()), {bike1._pk})
         bike2 = Bike(name="tommasini")
-        self.assertEqual(set(Bike.collection()), set([bike1._pk, bike2._pk]))
+        self.assertEqual(set(Bike.collection()), {bike1._pk, bike2._pk})
 
     def test_filter_from_kwargs(self):
         self.assertEqual(len(list(Boat.collection())), 4)
@@ -203,14 +203,14 @@ class SliceTest(CollectionBaseTest):
     def test_slicing_is_reset_on_next_call(self):
         # test whole content
         collection = Boat.collection()
-        self.assertEqual(set(collection[1:]), set(['2', '3', '4']))
-        self.assertEqual(set(collection), set(['1', '2',  '3', '4']))
+        self.assertEqual(set(collection[1:]), {'2', '3', '4'})
+        self.assertEqual(set(collection), {'1', '2', '3', '4'})
 
         # test __iter__
         collection = Boat.collection()
-        self.assertEqual(set(collection[1:]), set(['2', '3', '4']))
+        self.assertEqual(set(collection[1:]), {'2', '3', '4'})
         all_pks = set([pk for pk in collection])
-        self.assertEqual(all_pks, set(['1', '2',  '3', '4']))
+        self.assertEqual(all_pks, {'1', '2', '3', '4'})
 
 
 class SortTest(CollectionBaseTest):
@@ -473,7 +473,7 @@ class InstancesTest(CollectionBaseTest):
 
     def test_call_to_primary_keys_should_cancel_instances(self):
         boats = set(Boat.collection().instances().primary_keys())
-        self.assertEqual(boats, set(['1', '2', '3', '4']))
+        self.assertEqual(boats, {'1', '2', '3', '4'})
 
 
 class LenTest(CollectionBaseTest):
@@ -494,7 +494,7 @@ class LenTest(CollectionBaseTest):
     def test_len_call_could_be_followed_by_a_iter(self):
         collection = Boat.collection(power="sail")
         self.assertEqual(len(collection), 3)
-        self.assertEqual(set(collection), set(['1', '2', '3']))
+        self.assertEqual(set(collection), {'1', '2', '3'})
 
     def test_len_should_work_with_slices(self):
         collection = Boat.collection(power="sail")[1:3]

--- a/tests/contrib/collection.py
+++ b/tests/contrib/collection.py
@@ -49,7 +49,7 @@ class CompatibilityTest(BaseTest):
 
         # test "all"
         all_pks = set(Group.collection())
-        self.assertEqual(all_pks, set(['1', '2', '3', '4']))
+        self.assertEqual(all_pks, {'1', '2', '3', '4'})
 
         # test "sort by"
         all_pks_by_name = list(Group.collection().sort(by='name', alpha=True))
@@ -57,7 +57,7 @@ class CompatibilityTest(BaseTest):
 
         # test "filter"
         active_pks = set(Group.collection(active=1))
-        self.assertEqual(active_pks, set(['1', '2']))
+        self.assertEqual(active_pks, {'1', '2'})
         first_group_pk = list(Group.collection(pk=1))
         self.assertEqual(first_group_pk, ['1', ])
         bad_groups = list(Group.collection(pk=10, active=1))
@@ -67,7 +67,7 @@ class CompatibilityTest(BaseTest):
         public_groups = list(Group.collection(public=1).instances())
         self.assertEqual(len(public_groups), 2)
         public_groups_pks = set([g._pk for g in public_groups])
-        self.assertEqual(public_groups_pks, set(['1', '3']))
+        self.assertEqual(public_groups_pks, {'1', '3'})
 
         # test "values"
         active_public_dicts = list(Group.collection(public=1, active=1)
@@ -186,13 +186,13 @@ class FieldOrModelAsValueForSortAndFilterTest(BaseTest):
         # test using field from same model, without updating its value
         group = Group(name='foo')
         collection = Group.collection(name=group.name)
-        attended = set([self.groups[0]._pk, group._pk])
+        attended = {self.groups[0]._pk, group._pk}
         self.assertEqual(set(collection), attended)
 
         # test using a field from same model, updating its value before running the collection
         group = Group(name='foo')
         collection = Group.collection(name=group.name)
-        attended = set([self.groups[1]._pk, group._pk])
+        attended = {self.groups[1]._pk, group._pk}
         group.name.hset('bar')
         self.assertEqual(set(collection), attended)
 
@@ -200,20 +200,20 @@ class FieldOrModelAsValueForSortAndFilterTest(BaseTest):
         # test using a field from another model, without updating its value
         query = FieldOrModelAsValueForSortAndFilterTest.Query(name='foo')
         collection = Group.collection(name=query.name)
-        attended = set([self.groups[0]._pk, ])
+        attended = {self.groups[0]._pk}
         self.assertEqual(set(collection), attended)
 
         # test using a field from another model, updating its value before running the collection
         query = FieldOrModelAsValueForSortAndFilterTest.Query(name='foo')
         collection = Group.collection(name=query.name)
-        attended = set([self.groups[1]._pk, ])
+        attended = {self.groups[1]._pk}
         query.name.hset('bar')
         self.assertEqual(set(collection), attended)
 
         # test using a field from another model, really creating the object later
         query = FieldOrModelAsValueForSortAndFilterTest.Query()
         collection = Group.collection(name=query.name)
-        attended = set([self.groups[2]._pk, ])
+        attended = {self.groups[2]._pk}
         query.name.hset('baz')
         self.assertEqual(set(collection), attended)
 
@@ -222,13 +222,13 @@ class FieldOrModelAsValueForSortAndFilterTest(BaseTest):
         # pass the pk, but value will be get when calling the collection
         collection = Group.collection(pk=group.pk)
         group.name.hset('aaa')  # create a pk for the object
-        attended = set([group.pk.get()])
+        attended = {group.pk.get()}
         self.assertEqual(set(collection), attended)
 
     def test_filter_should_accept_instance_as_value(self):
         group = Group(name='foo')
         collection = Group.collection(pk=group)
-        attended = set([group._pk, ])
+        attended = {group._pk}
         self.assertEqual(set(collection), attended)
 
 
@@ -237,26 +237,26 @@ class FilterTest(BaseTest):
     def test_filter_method_should_add_filter(self):
         # test with one call
         collection = Group.collection(active=1).filter(public=1)
-        self.assertEqual(set(collection), set(['1']))
+        self.assertEqual(set(collection), {'1'})
         # test with two calls
         collection = Group.collection(active=1)
-        self.assertEqual(set(collection), set(['1', '2']))
+        self.assertEqual(set(collection), {'1', '2'})
         collection.filter(public=1)
-        self.assertEqual(set(collection), set(['1']))
+        self.assertEqual(set(collection), {'1'})
         # test with a pk
         collection = Group.collection(active=1).filter(pk=2)
-        self.assertEqual(set(collection), set(['2']))
+        self.assertEqual(set(collection), {'2'})
         collection = Group.collection(active=1).filter(id=1)
-        self.assertEqual(set(collection), set(['1']))
+        self.assertEqual(set(collection), {'1'})
         collection = Group.collection(active=1).filter(id=10)
         self.assertEqual(set(collection), set())
         # test with pk, then filter with other
         collection = Group.collection(pk=2).filter(active=1)
-        self.assertEqual(set(collection), set(['2']))
+        self.assertEqual(set(collection), {'2'})
 
     def test_filter_calls_could_be_chained(self):
         collection = Group.collection().filter(active=1).filter(public=1).filter(pk=1)
-        self.assertEqual(set(collection), set(['1']))
+        self.assertEqual(set(collection), {'1'})
 
     def test_redefining_filter_should_return_empty_result(self):
         collection = Group.collection(active=1).filter(active=0)
@@ -269,9 +269,9 @@ class FilterTest(BaseTest):
 
     def test_filter_should_accept_pks(self):
         collection = Group.collection(pk=1)
-        self.assertEqual(set(collection), set(['1']))
+        self.assertEqual(set(collection), {'1'})
         collection.filter(id=1)
-        self.assertEqual(set(collection), set(['1']))
+        self.assertEqual(set(collection), {'1'})
         collection.filter(pk=2)
         self.assertEqual(set(collection), set())
 
@@ -330,36 +330,36 @@ class IntersectTest(BaseTest):
         self.connection.sadd(set_key, 1, 2)
         collection = set(Group.collection().intersect(set_key))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         set_key = unique_key(self.connection)
         self.connection.sadd(set_key, 1, 2, 10, 50)
         collection = set(Group.collection().intersect(set_key))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_accept_sortedset_key_as_string(self):
         zset_key = unique_key(self.connection)
         self.connection.zadd(zset_key, 1.0, 1, 2.0, 2)
         collection = set(Group.collection().intersect(zset_key))
         self.assertEqual(self.last_interstore_call['command'], 'zinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         zset_key = unique_key(self.connection)
         self.connection.zadd(zset_key, 1.0, 1, 2.0, 2, 10.0, 10, 50.0, 50)
         collection = set(Group.collection().intersect(zset_key))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_accept_list_key_as_string(self):
         list_key = unique_key(self.connection)
         self.connection.lpush(list_key, 1, 2)
         collection = set(Group.collection().intersect(list_key))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         list_key = unique_key(self.connection)
         self.connection.lpush(list_key, 1, 2, 10, 50)
         collection = set(Group.collection().intersect(list_key))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_not_accept_string_key_as_string(self):
         str_key = unique_key(self.connection)
@@ -380,28 +380,28 @@ class IntersectTest(BaseTest):
         self.assertEqual(collection, set())
 
     def test_intersect_should_accept_set(self):
-        collection = set(Group.collection().intersect(set([1, 2])))
+        collection = set(Group.collection().intersect({1, 2}))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
-        collection = set(Group.collection().intersect(set([1, 2, 10, 50])))
-        self.assertEqual(collection, set(['1', '2']))
+        collection = set(Group.collection().intersect({1, 2, 10, 50}))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_accept_list(self):
         collection = set(Group.collection().intersect([1, 2]))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         collection = set(Group.collection().intersect([1, 2, 10, 50]))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_accept_tuple(self):
         collection = set(Group.collection().intersect((1, 2)))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         collection = set(Group.collection().intersect((1, 2, 10, 50)))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_accept_setfield(self):
         container = GroupsContainer()
@@ -409,11 +409,11 @@ class IntersectTest(BaseTest):
         container.groups_set.sadd(1, 2)
         collection = set(Group.collection().intersect(container.groups_set))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         container.groups_set.sadd(10, 50)
         collection = set(Group.collection().intersect(container.groups_set))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_accept_listfield_without_scripting(self):
         container = GroupsContainer()
@@ -421,11 +421,11 @@ class IntersectTest(BaseTest):
         container.groups_list.lpush(1, 2)
         collection = set(Group.collection().intersect(container.groups_list))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         container.groups_list.lpush(10, 50)
         collection = set(Group.collection().intersect(container.groups_list))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     @unittest.skipUnless(test_database.support_scripting(), "Redis scripting not available")
     def test_intersect_should_accept_listfield_via_scripting(self):
@@ -434,22 +434,22 @@ class IntersectTest(BaseTest):
         container.groups_list.lpush(1, 2)
         collection = set(Group.collection().intersect(container.groups_list))
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         container.groups_list.lpush(10, 50)
         collection = set(Group.collection().intersect(container.groups_list))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_intersect_should_accept_sortedsetfield(self):
         container = GroupsContainer()
 
         container.groups_sortedset.zadd(1.0, 1, 2.0, 2)
         collection = set(Group.collection().intersect(container.groups_sortedset))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
         container.groups_sortedset.zadd(10.0, 10, 50.0, 50)
         collection = set(Group.collection().intersect(container.groups_sortedset))
-        self.assertEqual(collection, set(['1', '2']))
+        self.assertEqual(collection, {'1', '2'})
 
     def test_passing_sortedset_in_intersect_use_zinterstore(self):
         container = GroupsContainer()
@@ -492,11 +492,11 @@ class IntersectTest(BaseTest):
 
     def test_intersect_can_be_called_many_times(self):
         collection = set(Group.collection().intersect([1, 2, 3, 10]).intersect([2, 3, 50]))
-        self.assertEqual(collection, set(['2', '3']))
+        self.assertEqual(collection, {'2', '3'})
 
     def test_intersect_can_be_called_with_filter(self):
         collection = Group.collection(active=1).filter(public=1).intersect([1, 2, 3, 10])
-        self.assertEqual(set(collection), set(['1']))
+        self.assertEqual(set(collection), {'1'})
         self.assertEqual(self.last_interstore_call['command'], 'sinterstore')
         collection = collection.intersect([2, 3, 50])
         self.assertEqual(set(collection), set())
@@ -696,7 +696,7 @@ class SortByScoreTest(BaseTest):
 
         # test without sorting by score
         collection = Group.collection(active=1).values_list('name', SORTED_SCORE)
-        self.assertEqual(set(collection), set([('bar', None), ('foo', None)]))
+        self.assertEqual(set(collection), {('bar', None), ('foo', None)})
 
         # test with pk
         collection = Group.collection(pk=1).values('name', SORTED_SCORE).sort(
@@ -867,7 +867,7 @@ class ValuesTest(BaseValuesTest):
         self.assertEqual(len(boats), 4)
         for boat in boats:
             self.assertTrue(isinstance(boat, dict))
-            self.assertEqual(set(boat.keys()), set(['pk', 'name', 'launched']))
+            self.assertEqual(set(boat.keys()), {'pk', 'name', 'launched'})
             test_boat = Boat(boat['pk'])
             self.assertEqual(test_boat.name.get(), boat['name'])
             self.assertEqual(test_boat.launched.get(), boat['launched'])
@@ -876,7 +876,7 @@ class ValuesTest(BaseValuesTest):
         boats = list(Boat.collection().values())
         self.assertEqual(len(boats), 4)
         self.assertTrue(isinstance(boats[0], dict))
-        self.assertEqual(set(boats[0].keys()), set(['pk', 'name', 'power', 'launched', 'length']))
+        self.assertEqual(set(boats[0].keys()), {'pk', 'name', 'power', 'launched', 'length'})
 
     def test_values_should_only_accept_simple_fields(self):
         with self.assertRaises(ValueError):
@@ -909,7 +909,7 @@ class ValuesTest(BaseValuesTest):
 
     def test_call_to_primary_keys_should_cancel_values(self):
         boats = set(Boat.collection().values('pk', 'name', 'launched').primary_keys())
-        self.assertEqual(boats, set(['1', '2', '3', '4']))
+        self.assertEqual(boats, {'1', '2', '3', '4'})
 
 
 class ValuesListTest(BaseValuesTest):
@@ -977,6 +977,6 @@ class ValuesListTest(BaseValuesTest):
 
     def test_call_to_primary_keys_should_cancel_values_list(self):
         boats = set(Boat.collection().values_list('pk', 'name', 'launched').primary_keys())
-        self.assertEqual(boats, set(['1', '2', '3', '4']))
+        self.assertEqual(boats, {'1', '2', '3', '4'})
         boats = set(Boat.collection().values_list('name', flat=True).primary_keys())
-        self.assertEqual(boats, set(['1', '2', '3', '4']))
+        self.assertEqual(boats, {'1', '2', '3', '4'})

--- a/tests/contrib/related.py
+++ b/tests/contrib/related.py
@@ -85,14 +85,14 @@ class RelatedNameTest(LimpydBaseTest):
         ybon = Person(name='ybon')
         ybon.prefered_group.set(core_devs._pk)
 
-        self.assertEqual(set(core_devs.person_set()), set([ybon._pk]))
+        self.assertEqual(set(core_devs.person_set()), {ybon._pk})
 
     def test_defined_related_name_should_exists_as_collection(self):
         core_devs = Group(name='limpyd core devs')
         ybon = Person(name='ybon')
         core_devs.owner.hset(ybon._pk)
 
-        self.assertEqual(set(ybon.owned_groups()), set([core_devs._pk]))
+        self.assertEqual(set(ybon.owned_groups()), {core_devs._pk})
         self.assertEqual(set(ybon.owned_groups()), set(Group.collection(owner=ybon._pk)))
 
     def test_placeholders_in_related_name_should_be_replaced(self):
@@ -107,7 +107,7 @@ class RelatedNameTest(LimpydBaseTest):
         ybon.most_hated_group.set(ms_php._pk)
 
         self.assertTrue(hasattr(ms_php, 'related_name_persontest_set'))
-        self.assertEqual(set(ms_php.related_name_persontest_set()), set([ybon._pk]))
+        self.assertEqual(set(ms_php.related_name_persontest_set()), {ybon._pk})
 
     def test_related_name_should_follow_namespace(self):
         class SubTest(object):
@@ -134,8 +134,8 @@ class RelatedNameTest(LimpydBaseTest):
                 person.first_group.set(group1._pk)
                 person.second_group.set(group2._pk)
 
-                self.assertEqual(set(group1.persontest_set()), set([person._pk]))
-                self.assertEqual(set(group2.persontest_set()), set([person._pk]))
+                self.assertEqual(set(group1.persontest_set()), {person._pk})
+                self.assertEqual(set(group2.persontest_set()), {person._pk})
 
         SubTest.run()
 
@@ -191,8 +191,8 @@ class RelatedNameTest(LimpydBaseTest):
 
         self.assertTrue(hasattr(other, 'related_name_sub_childa_related'))
         self.assertTrue(hasattr(other, 'related_name_sub_childb_related'))
-        self.assertEqual(set(other.related_name_sub_childa_related()), set([childa._pk]))
-        self.assertEqual(set(other.related_name_sub_childb_related()), set([childb._pk]))
+        self.assertEqual(set(other.related_name_sub_childa_related()), {childa._pk})
+        self.assertEqual(set(other.related_name_sub_childb_related()), {childb._pk})
 
     def test_related_name_as_invalid_identifier_should_raise(self):
         with self.assertRaises(ImplementationError):
@@ -233,7 +233,7 @@ class RelatedCollectionTest(LimpydBaseTest):
         test2 = set(ybon.membership(status='private'))
 
         self.assertEqual(test1, test2)
-        self.assertEqual(test2, set([core_devs._pk]))
+        self.assertEqual(test2, {core_devs._pk})
 
 
 class MultiValuesCollectionTest(LimpydBaseTest):
@@ -252,14 +252,14 @@ class MultiValuesCollectionTest(LimpydBaseTest):
 
     def test_return_value_of_collection(self):
         members_pk = set(self.core_devs.members())
-        self.assertTrue(members_pk, set(['twidi', 'ybon']))
+        self.assertTrue(members_pk, {'twidi', 'ybon'})
         members_instances = list(self.core_devs.members().instances())
         self.assertEqual(len(members_instances), 2)
         self.assertTrue(isinstance(members_instances[0], Person))
 
     def test_additional_filters(self):
         members_pk = set(self.core_devs.members(name='twidi'))
-        self.assertEqual(members_pk, set(['twidi']))
+        self.assertEqual(members_pk, {'twidi'})
 
         members_pk = set(self.core_devs.members(name='diox'))
         self.assertEqual(members_pk, set())
@@ -281,7 +281,7 @@ class MultiValuesCollectionTest(LimpydBaseTest):
         core_devs.members.rpush(self.twidi)
 
         members_pk = set(core_devs.members())
-        self.assertTrue(members_pk, set(['twidi', 'ybon']))
+        self.assertTrue(members_pk, {'twidi', 'ybon'})
         members_instances = list(core_devs.members().instances())
         self.assertEqual(len(members_instances), 2)
         self.assertTrue(isinstance(members_instances[0], Person))
@@ -297,7 +297,7 @@ class MultiValuesCollectionTest(LimpydBaseTest):
         core_devs.members.zadd(50, self.twidi)
 
         members_pk = set(core_devs.members())
-        self.assertTrue(members_pk, set(['twidi', 'ybon']))
+        self.assertTrue(members_pk, {'twidi', 'ybon'})
         members_instances = list(core_devs.members().instances())
         self.assertEqual(len(members_instances), 2)
         self.assertTrue(isinstance(members_instances[0], Person))
@@ -325,12 +325,12 @@ class FKTest(LimpydBaseTest):
         # test with FKInstanceHashField
         core_devs.owner.hset(ybon)
         self.assertEqual(core_devs.owner.hget(), ybon._pk)
-        self.assertEqual(set(ybon.owned_groups()), set([core_devs._pk]))
+        self.assertEqual(set(ybon.owned_groups()), {core_devs._pk})
 
         # test with FKStringField
         ybon.prefered_group.set(core_devs)
         self.assertEqual(ybon.prefered_group.get(), core_devs._pk)
-        self.assertEqual(set(core_devs.person_set()), set([ybon._pk]))
+        self.assertEqual(set(core_devs.person_set()), {ybon._pk})
 
     def test_fk_can_be_given_as_fk(self):
         core_devs = Group(name='limpyd core devs')
@@ -340,7 +340,7 @@ class FKTest(LimpydBaseTest):
         core_devs.owner.hset(ybon)
         fan_boys.owner.hset(core_devs.owner)
         self.assertEqual(fan_boys.owner.hget(), ybon._pk)
-        self.assertEqual(set(ybon.owned_groups()), set([core_devs._pk, fan_boys._pk]))
+        self.assertEqual(set(ybon.owned_groups()), {core_devs._pk, fan_boys._pk})
 
     def test_can_update_fk(self):
         core_devs = Group(name='limpyd core devs')
@@ -348,11 +348,11 @@ class FKTest(LimpydBaseTest):
         twidi = Person(name='twidi')
 
         core_devs.owner.hset(ybon)
-        self.assertEqual(set(ybon.owned_groups()), set([core_devs._pk]))
+        self.assertEqual(set(ybon.owned_groups()), {core_devs._pk})
 
         core_devs.owner.hset(twidi)
         self.assertEqual(set(ybon.owned_groups()), set())
-        self.assertEqual(set(twidi.owned_groups()), set([core_devs._pk]))
+        self.assertEqual(set(twidi.owned_groups()), {core_devs._pk})
 
     def test_many_fk_can_be_set_on_same_object(self):
         core_devs = Group(name='limpyd core devs')
@@ -361,7 +361,7 @@ class FKTest(LimpydBaseTest):
 
         core_devs.owner.hset(twidi)
         fan_boys.owner.hset(twidi)
-        self.assertEqual(set(twidi.owned_groups()), set([core_devs._pk, fan_boys._pk]))
+        self.assertEqual(set(twidi.owned_groups()), {core_devs._pk, fan_boys._pk})
 
     def test_fk_can_be_set_on_same_model(self):
         main_group = Group(name='limpyd groups')
@@ -370,7 +370,7 @@ class FKTest(LimpydBaseTest):
 
         core_devs.parent.set(main_group)
         fan_boys.parent.set(main_group)
-        self.assertEqual(set(main_group.children()), set([core_devs._pk, fan_boys._pk]))
+        self.assertEqual(set(main_group.children()), {core_devs._pk, fan_boys._pk})
 
     def test_calling_instance_on_fkfield_should_retrieve_the_related_instance(self):
         twidi = Person(name='twidi')
@@ -420,9 +420,9 @@ class M2MSetTest(LimpydBaseTest):
 
         core_devs.members.sadd(ybon._pk, twidi)
 
-        self.assertEqual(core_devs.members.smembers(), set([twidi._pk, ybon._pk]))
-        self.assertEqual(set(ybon.membership()), set([core_devs._pk]))
-        self.assertEqual(set(twidi.membership()), set([core_devs._pk]))
+        self.assertEqual(core_devs.members.smembers(), {twidi._pk, ybon._pk})
+        self.assertEqual(set(ybon.membership()), {core_devs._pk})
+        self.assertEqual(set(twidi.membership()), {core_devs._pk})
 
     def test_set_m2m_values_can_be_given_as_fk(self):
         core_devs = Group(name='limpyd core devs')
@@ -430,7 +430,7 @@ class M2MSetTest(LimpydBaseTest):
 
         core_devs.owner.hset(ybon)
         core_devs.members.sadd(core_devs.owner)
-        self.assertEqual(core_devs.members.smembers(), set([ybon._pk]))
+        self.assertEqual(core_devs.members.smembers(), {ybon._pk})
 
     def test_removed_m2m_values_should_update_related_collection(self):
         core_devs = Group(name='limpyd core devs')
@@ -440,9 +440,9 @@ class M2MSetTest(LimpydBaseTest):
         core_devs.members.sadd(ybon, twidi)
         core_devs.members.srem(ybon)
 
-        self.assertEqual(core_devs.members.smembers(), set([twidi._pk]))
+        self.assertEqual(core_devs.members.smembers(), {twidi._pk})
         self.assertEqual(set(ybon.membership()), set())
-        self.assertEqual(set(twidi.membership()), set([core_devs._pk]))
+        self.assertEqual(set(twidi.membership()), {core_devs._pk})
 
     def test_m2m_can_be_set_on_the_same_model(self):
         ybon = Person(name='ybon')
@@ -450,8 +450,8 @@ class M2MSetTest(LimpydBaseTest):
 
         twidi.following.sadd(ybon)
 
-        self.assertEqual(twidi.following.smembers(), set([ybon._pk]))
-        self.assertEqual(set(ybon.followers()), set([twidi._pk]))
+        self.assertEqual(twidi.following.smembers(), {ybon._pk})
+        self.assertEqual(set(ybon.followers()), {twidi._pk})
 
     def test_deleting_an_object_must_clean_m2m(self):
         core_devs = Group(name='limpyd core devs')
@@ -461,8 +461,8 @@ class M2MSetTest(LimpydBaseTest):
         core_devs.members.sadd(ybon._pk, twidi)
         ybon.delete()
 
-        self.assertEqual(core_devs.members.smembers(), set([twidi._pk]))
-        self.assertEqual(set(twidi.membership()), set([core_devs._pk]))
+        self.assertEqual(core_devs.members.smembers(), {twidi._pk})
+        self.assertEqual(set(twidi.membership()), {core_devs._pk})
 
     def test_deleting_a_m2m_should_clear_collections(self):
         core_devs = Group(name='limpyd core devs')
@@ -490,8 +490,8 @@ class M2MListTest(LimpydBaseTest):
         core_devs.members.rpush(ybon._pk, twidi)
 
         self.assertEqual(core_devs.members.lrange(0, -1), [ybon._pk, twidi._pk])
-        self.assertEqual(set(ybon.members_set2()), set([core_devs._pk]))
-        self.assertEqual(set(twidi.members_set2()), set([core_devs._pk]))
+        self.assertEqual(set(ybon.members_set2()), {core_devs._pk})
+        self.assertEqual(set(twidi.members_set2()), {core_devs._pk})
 
 
 class M2MSortedSetTest(LimpydBaseTest):
@@ -508,8 +508,8 @@ class M2MSortedSetTest(LimpydBaseTest):
         core_devs.members.zadd(20, ybon, 10, twidi._pk)
 
         self.assertEqual(core_devs.members.zrange(0, -1), [twidi._pk, ybon._pk])
-        self.assertEqual(set(ybon.members_set3()), set([core_devs._pk]))
-        self.assertEqual(set(twidi.members_set3()), set([core_devs._pk]))
+        self.assertEqual(set(ybon.members_set3()), {core_devs._pk})
+        self.assertEqual(set(twidi.members_set3()), {core_devs._pk})
 
     def test_zset_m2m_values_are_scored(self):
         core_devs = M2MSortedSetTest.Group3(name='limpyd core devs')

--- a/tests/fields/hash.py
+++ b/tests/fields/hash.py
@@ -32,7 +32,7 @@ class HashFieldTest(BaseModelTest):
     def test_hmset_should_be_indexable(self):
         obj = self.model()
         obj.headers.hmset(**{'from': 'you@moon.io'})
-        self.assertEqual(set(self.model.collection(headers__from='you@moon.io')), set([obj._pk]))
+        self.assertEqual(set(self.model.collection(headers__from='you@moon.io')), {obj._pk})
 
         # Now change value and check first has been deindexed and new redindexed
         obj.headers.hmset(**{'from': 'you@mars.io'})
@@ -45,7 +45,7 @@ class HashFieldTest(BaseModelTest):
         self.assertEqual(obj.headers.hget('from'), 'someone@cassini.io')
 
         self.assertEqual(set(self.model.collection(headers__from='someone@cassini.io')),
-                         set([obj._pk]))
+                         {obj._pk})
 
         # Now change value and check first has been deindexed and new redindexed
         obj.headers.hset('from', 'someoneelse@cassini.io')
@@ -144,7 +144,7 @@ class HashFieldTest(BaseModelTest):
         obj = self.model(headers=headers)
         self.assertEqual(
             set(obj.headers.hkeys()),
-            set(['from', 'to'])
+            {'from', 'to'}
         )
 
     def test_hvals_should_return_all_values(self):
@@ -155,7 +155,7 @@ class HashFieldTest(BaseModelTest):
         obj = self.model(headers=headers)
         self.assertEqual(
             set(obj.headers.hvals()),
-            set(['foo@bar.com', 'me@world.org'])
+            {'foo@bar.com', 'me@world.org'}
         )
 
     def test_hexists_should_check_if_key_exists(self):

--- a/tests/fields/instancehash.py
+++ b/tests/fields/instancehash.py
@@ -70,15 +70,15 @@ class HMTest(LimpydBaseTest):
     def test_hmset_should_index_values(self):
         obj = self.HMTestModel()
         obj.hmset(foo='FOO', bar='BAR', baz='BAZ')
-        self.assertEqual(set(self.HMTestModel.collection(bar='BAR')), set([obj._pk]))
-        self.assertEqual(set(self.HMTestModel.collection(baz='BAZ')), set([obj._pk]))
+        self.assertEqual(set(self.HMTestModel.collection(bar='BAR')), {obj._pk})
+        self.assertEqual(set(self.HMTestModel.collection(baz='BAZ')), {obj._pk})
 
     def test_hdel_should_deindex_values(self):
         obj = self.HMTestModel()
         obj.hmset(foo='FOO', bar='BAR', baz='BAZ')
         obj.hdel('foo', 'bar')
         self.assertEqual(set(self.HMTestModel.collection(bar='BAR')), set([]))
-        self.assertEqual(set(self.HMTestModel.collection(baz='BAZ')), set([obj._pk]))
+        self.assertEqual(set(self.HMTestModel.collection(baz='BAZ')), {obj._pk})
 
     def test_hmset_should_not_index_if_an_error_occurs(self):
         self.HMTestModel(baz="BAZ")
@@ -106,18 +106,18 @@ class HMTest(LimpydBaseTest):
     def test_hkeys_should_return_all_set_fieldnames(self):
         obj = self.HMTestModel(foo='FOO', bar='BAR')
         data = obj.hkeys()
-        self.assertEqual(set(data), set(['foo', 'bar']))
+        self.assertEqual(set(data), {'foo', 'bar'})
         obj.foo.hdel()
         data = obj.hkeys()
-        self.assertEqual(set(data), set(['bar', ]))
+        self.assertEqual(set(data), {'bar'})
 
     def test_hvals_should_return_all_set_values(self):
         obj = self.HMTestModel(foo='FOO', bar='BAR')
         data = obj.hvals()
-        self.assertEqual(set(data), set(['FOO', 'BAR']))
+        self.assertEqual(set(data), {'FOO', 'BAR'})
         obj.foo.hdel()
         data = obj.hvals()
-        self.assertEqual(set(data), set(['BAR', ]))
+        self.assertEqual(set(data), {'BAR'})
 
     def test_hlen_should_return_number_of_set_fields(self):
         obj = self.HMTestModel(foo='FOO', bar='BAR')

--- a/tests/fields/pk.py
+++ b/tests/fields/pk.py
@@ -91,17 +91,17 @@ class PKFieldTest(LimpydBaseTest):
         # default auto pk
         self.AutoPkModel(name="foo")
         self.AutoPkModel(name="foo")
-        self.assertEqual(set(self.AutoPkModel.collection(name="foo")), set(['1', '2']))
-        self.assertEqual(set(self.AutoPkModel.collection(pk=1)), set(['1', ]))
-        self.assertEqual(set(self.AutoPkModel.collection(name="foo", pk=1)), set(['1', ]))
+        self.assertEqual(set(self.AutoPkModel.collection(name="foo")), {'1', '2'})
+        self.assertEqual(set(self.AutoPkModel.collection(pk=1)), {'1'})
+        self.assertEqual(set(self.AutoPkModel.collection(name="foo", pk=1)), {'1'})
         self.assertEqual(set(self.AutoPkModel.collection(name="foo", pk=3)), set())
         self.assertEqual(set(self.AutoPkModel.collection(name="bar", pk=1)), set())
         # specific pk
         self.NotAutoPkModel(name="foo", pk="100")
         self.NotAutoPkModel(name="foo", pk="200")
-        self.assertEqual(set(self.NotAutoPkModel.collection(name="foo")), set(['100', '200']))
-        self.assertEqual(set(self.NotAutoPkModel.collection(pk=100)), set(['100', ]))
-        self.assertEqual(set(self.NotAutoPkModel.collection(name="foo", pk=100)), set(['100', ]))
+        self.assertEqual(set(self.NotAutoPkModel.collection(name="foo")), {'100', '200'})
+        self.assertEqual(set(self.NotAutoPkModel.collection(pk=100)), {'100'})
+        self.assertEqual(set(self.NotAutoPkModel.collection(name="foo", pk=100)), {'100'})
         self.assertEqual(set(self.NotAutoPkModel.collection(name="foo", pk=300)), set())
         self.assertEqual(set(self.NotAutoPkModel.collection(name="bar", pk=100)), set())
 
@@ -134,8 +134,8 @@ class PKFieldTest(LimpydBaseTest):
         self.assertEqual(same_obj._pk, same_obj2._pk)
         self.assertEqual(same_obj.id.get(), same_obj2.id.get())
         # collection via pk or id
-        self.assertEqual(set(self.RedefinedNotAutoPkField.collection(pk=1)), set(['1', ]))
-        self.assertEqual(set(self.RedefinedNotAutoPkField.collection(id=2)), set(['2', ]))
+        self.assertEqual(set(self.RedefinedNotAutoPkField.collection(pk=1)), {'1'})
+        self.assertEqual(set(self.RedefinedNotAutoPkField.collection(id=2)), {'2'})
 
     def test_cannot_set_pk_with_two_names(self):
         with self.assertRaises(ValueError):

--- a/tests/model.py
+++ b/tests/model.py
@@ -549,14 +549,14 @@ class InheritanceTest(LimpydBaseTest):
         """
         bike = Bike()
         self.assertEqual(len(bike._fields), 4)
-        self.assertEqual(set(bike._fields), set(['pk', 'name', 'wheels', 'passengers']))
+        self.assertEqual(set(bike._fields), {'pk', 'name', 'wheels', 'passengers'})
         motorbike = MotorBike()
         self.assertEqual(len(motorbike._fields), 5)
         self.assertEqual(set(motorbike._fields),
-                         set(['pk', 'name', 'wheels', 'passengers', 'power']))
+                         {'pk', 'name', 'wheels', 'passengers', 'power'})
         boat = Boat()
         self.assertEqual(len(boat._fields), 5)
-        self.assertEqual(set(boat._fields), set(['pk', 'name', 'launched', 'power', 'length']))
+        self.assertEqual(set(boat._fields), {'pk', 'name', 'launched', 'power', 'length'})
 
     def test_inheritance_values(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,7 +51,3 @@ class LimpydBaseTestTest(LimpydBaseTest):
         self.assertEqual(self.count_keys(), 0)
         self.connection.set('__test__', '__test__')
         self.assertEqual(self.count_keys(), 1)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Some slicing were not managed at all, retrieving the wrong number of
data.
It is now corrected, with also more cases where we try to limit the data
returned by redis
To be sure that the data is always correctly returned, in the tests we
compare the result of slicing a collection to the same slicing of a
normal python list. Same for indexing (both in `__getitem__`)

PS: depnds on #109 