### PR TITLE
Adapt to support redis-py 3+ (only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,11 @@ python:
  - "3.6"
  - "3.7"
  - "3.8-dev"
- - "pypy"
- - "pypy3"
-
-env:
- - REDIS="redis==2.9.1"
- - REDIS="redis==2.10.6"
+ - "pypy"  # 2.7
+ - "pypy3"  # 3.6
 
 install:
-- "pip install ."
-- "pip install $REDIS"
+- pip install .
 
 script: "python run_tests.py"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Release *v2.0.dev0* - ``2019-10-07``
+------------------------------------
+* Support for redis-py >= 3 only
+* Support for redis-server >= 3 only
+* Breaking change: `zadd` value/scores cannot be passed as positional arguments anymore
+* Breaking change: `zadd` flags other than `ch` are explicitely not supported
+* Breaking change: `zincrby` arguments are swaped (`amount, value` instead of `value, amount`)
+* Breaking change: Redis server with `LUA` scripting support is mandatory
+
 Release *v1.3.1* - ``2019-10-11``
 ---------------------------------
 * Resolve race condition in `get_or_connect`

--- a/README.rst
+++ b/README.rst
@@ -69,15 +69,13 @@ Install
 
 Python versions ``2.7`` and ``3.5`` to ``3.8`` are supported (CPython and PyPy).
 
-Redis-py_ versions ``>= 2.9.1`` and ``< 2.11`` are supported.
+Redis-py_ versions ``>= 3`` are supported, with redis-server versions ``>= 3``.
 
 .. code:: bash
 
     pip install redis-limpyd
 
-
-Note: Version 1.0, 1.0.1 and 1.1 where broken so removed from PyPI
-
+For Redis-py_ versions < 3, please use limpyd version ``1.3.1`` (or later in ``1.x`` versions)
 
 Documentation
 =============

--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -564,7 +564,7 @@ You can use this model like this:
 .. code:: python
 
     >>> example = Example()
-    >>> example.stuff.zadd(foo=2.5, bar=1.1)
+    >>> example.stuff.zadd(foo=2.5, bar=1.1)  # or example.stuff.zadd({'foo': 2.5, 'bar': 1.1})
     2  # number of values added to the sorted set
     >>> example.stuff.zrange(0, -1)
     ['bar', 'foo']
@@ -597,7 +597,7 @@ Getters
 Modifiers
 """""""""
 
-- ``zadd``
+- ``zadd`` (Flag ``ch`` is supported. Flags ``nx``, ``xx`` and ``incr`` are not)
 - ``zincrby``
 - ``zrem``
 - ``zremrangebyrank``

--- a/limpyd/contrib/database.py
+++ b/limpyd/contrib/database.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import threading
 
-from redis.client import StrictPipeline
+from redis.client import Pipeline
 from redis.exceptions import WatchError
 
 from limpyd.database import RedisDatabase
@@ -105,7 +105,7 @@ class PipelineDatabase(RedisDatabase):
             self._pipelined_connection = None
 
 
-class _Pipeline(StrictPipeline):
+class _Pipeline(Pipeline):
     """
     A subclass of the redis pipeline class used by the database object, which
     save its internal connection and replace it by the pipeline, allowing

--- a/limpyd/contrib/related.py
+++ b/limpyd/contrib/related.py
@@ -519,9 +519,8 @@ class M2MSortedSetField(MultiValuesRelatedFieldMixin, fields.SortedSetField):
         """
         if 'values_callback' not in kwargs:
             kwargs['values_callback'] = self.from_python_many
-        pieces = fields.SortedSetField.coerce_zadd_args(*args, **kwargs)
-        return super(M2MSortedSetField, self).zadd(*pieces)
+        return super(M2MSortedSetField, self).zadd(*args, **kwargs)
 
-    def zincrby(self, value, amount=1):
+    def zincrby(self, amount, value):
         value = self.from_python(value)
-        return super(M2MSortedSetField, self).zincrby(value, amount)
+        return super(M2MSortedSetField, self).zincrby(amount, value)

--- a/limpyd/exceptions.py
+++ b/limpyd/exceptions.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 __all__ = [
+    "LimpydException",
     "UniquenessError",
     "ImplementationError",
     "DoesNotExist",

--- a/limpyd/indexes.py
+++ b/limpyd/indexes.py
@@ -909,23 +909,19 @@ class BaseRangeIndex(BaseIndex):
             # to avoid registering it many times
             script_dict=self.__class__.lua_filter_script,
             keys=[key, tmp_key],
-            args=[key_type, start, end, exclude] + list(args)
+            args=[key_type, start, end, exclude or ""] + list(args)  # None is refused by redis-py so we pass ""
         )
 
     def get_filtered_keys(self, suffix, *args, **kwargs):
         """Returns the index key for the given args "value" (`args`)
 
-        Parameters
-        ----------
-        kwargs: dict
-            use_lua: bool
-                Default to ``True``, if scripting is supported.
-                If ``True``, the process of reading from the sorted-set, extracting
-                the primary keys, excluding some values if needed, and putting the
-                primary keys in a set or zset, is done in lua at the redis level.
-                Else, data is fetched, manipulated here, then returned to redis.
+        For the parameters, see ``BaseIndex.get_filtered_keys``
 
-        For the other parameters, see ``BaseIndex.get_filtered_keys``
+        Notes
+        -----
+        The process of reading from the sorted-set, extracting the primary keys, excluding some
+        values if needed, and putting the primary keys in a set or zset, is done in lua at the
+        redis level.
 
         """
 
@@ -965,31 +961,20 @@ class BaseRangeIndex(BaseIndex):
 
             return [(tmp_key, key_type, True)]
 
-        use_lua = self.model.database.support_scripting() and kwargs.get('use_lua', True)
-
         key = self.get_storage_key(*args)
         value = self.normalize_value(args[-1], transform=False)
 
         real_suffix = self.remove_prefix(suffix)
 
-        if use_lua:
-            start, end, exclude = self.get_boundaries(real_suffix, value)
-            self.call_script(key, tmp_key, key_type, start, end, exclude)
-        else:
-            pks = self.get_pks_for_filter(key, real_suffix, value)
-            if pks:
-                if key_type == 'set':
-                    self.connection.sadd(tmp_key, *pks)
-                else:
-                    self.connection.zadd(tmp_key, **{pk: idx for idx, pk in enumerate(pks)})
+        start, end, exclude = self.get_boundaries(real_suffix, value)
+        self.call_script(key, tmp_key, key_type, start, end, exclude)
 
         return [(tmp_key, key_type, True)]
 
     def get_pks_for_filter(self, key, filter_type, value):
         """Extract the pks from the zset key for the given type and value
 
-        This is used for the uniqueness check and for the filtering if scripting
-        is not used
+        This is used for the uniqueness check
 
         Parameters
         ----------
@@ -1081,24 +1066,6 @@ class TextRangeIndex(BaseRangeIndex):
         """
     }
 
-    def __init__(self, field):
-        """Check that the database supports the zrangebylex redis command"""
-        super(TextRangeIndex, self).__init__(field)
-
-        try:
-            model = self.model
-        except AttributeError:
-            # index not yet tied to an field tied to a model
-            pass
-        else:
-            if not self.model.database.support_zrangebylex():
-                raise LimpydException(
-                    'Your redis version %s does not seems to support ZRANGEBYLEX '
-                    'so range indexes are not usable' % (
-                        '.'.join(str(part) for part in self.model.database.redis_version)
-                    )
-                )
-
     def prepare_value_for_storage(self, value, pk):
         """Prepare the value to be stored in the zset
 
@@ -1138,7 +1105,7 @@ class TextRangeIndex(BaseRangeIndex):
 
         """
 
-        self.connection.zadd(key, 0, value)
+        self.connection.zadd(key, {value: 0})
 
     def unstore(self, key, pk, value):
         """Remove the value/pk from the sorted set index
@@ -1319,7 +1286,7 @@ class NumberRangeIndex(BaseRangeIndex):
         We simple store the pk as a member of the sorted set with the value being the score
         """
 
-        self.connection.zadd(key, value, pk)
+        self.connection.zadd(key, {pk: value})
 
     def unstore(self, key, pk, value):
         """Remove the value/pk from the sorted set index

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = redis-limpyd
-version = 1.3.1
+version = 2.0.dev0
 author = Yohan Boniface
 author_email = yb@enix.org
 maintainer = Stephane "Twidi" Angel
@@ -33,7 +33,7 @@ classifiers =
 zip_safe = True
 packages = find:
 install_requires =
-    redis>=2.9.1,<2.11
+    redis>=3
     future
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 import sys
 import unittest
 
-from redis import VERSION as redispy_version, Redis
+from redis import Redis
 
 from limpyd.database import (RedisDatabase, DEFAULT_CONNECTION_SETTINGS)
 
@@ -19,9 +19,7 @@ test_database = RedisDatabase(**TEST_CONNECTION_SETTINGS)
 
 class LimpydBaseTest(unittest.TestCase):
 
-    COUNT_LOCK_COMMANDS = 3
-    if redispy_version >= (2, 10, 0):
-        COUNT_LOCK_COMMANDS = 6
+    COUNT_LOCK_COMMANDS = 4
 
     database = test_database
 
@@ -217,7 +215,3 @@ class _AssertNumCommandsContext(object):
                 )
             )
 
-skip_if_no_zrangebylex = (
-    not hasattr(Redis, 'zrangebylex'),
-    'Redis-py %s does not support zrangebylex' % '.'.join(map(str, redispy_version))
-)

--- a/tests/contrib/indexes.py
+++ b/tests/contrib/indexes.py
@@ -9,7 +9,7 @@ from limpyd.contrib.indexes import MultiIndexes, DateIndex, DateTimeIndex, Simpl
 from limpyd.exceptions import ImplementationError, UniquenessError
 from limpyd.indexes import BaseIndex, NumberRangeIndex, TextRangeIndex, EqualIndex
 
-from ..base import LimpydBaseTest, skip_if_no_zrangebylex
+from ..base import LimpydBaseTest
 from ..indexes import ReverseEqualIndex
 from ..model import TestRedisModel
 
@@ -223,7 +223,6 @@ class DateTimeModelTest(TestRedisModel):
     unique_simple_datetime = fields.InstanceHashField(indexable=True, indexes=[SimpleDateTimeIndex], unique=True)
 
 
-@unittest.skipIf(*skip_if_no_zrangebylex)
 class DateTimeIndexesTestCase(LimpydBaseTest):
 
     def test_date_index(self):

--- a/tests/contrib/related.py
+++ b/tests/contrib/related.py
@@ -293,8 +293,8 @@ class MultiValuesCollectionTest(LimpydBaseTest):
             members = M2MSortedSetField(Person, related_name='members_zset')
 
         core_devs = GroupAsSortedSet(name='limpyd core devs')
-        core_devs.members.zadd(100, self.ybon)
-        core_devs.members.zadd(50, self.twidi)
+        core_devs.members.zadd({self.ybon: 100})
+        core_devs.members.zadd({self.twidi: 50})
 
         members_pk = set(core_devs.members())
         self.assertTrue(members_pk, {'twidi', 'ybon'})
@@ -505,7 +505,7 @@ class M2MSortedSetTest(LimpydBaseTest):
         ybon = Person(name='ybon')
         twidi = Person(name='twidi')
 
-        core_devs.members.zadd(20, ybon, 10, twidi._pk)
+        core_devs.members.zadd({ybon: 20, twidi._pk: 10})
 
         self.assertEqual(core_devs.members.zrange(0, -1), [twidi._pk, ybon._pk])
         self.assertEqual(set(ybon.members_set3()), {core_devs._pk})
@@ -516,7 +516,7 @@ class M2MSortedSetTest(LimpydBaseTest):
         ybon = Person(name='ybon')
         twidi = Person(name='twidi')
 
-        core_devs.members.zadd(20, ybon, 10, twidi)
+        core_devs.members.zadd({ybon: 20, twidi: 10})
 
         self.assertEqual(core_devs.members.zrange(0, -1, withscores=True), [
             (twidi._pk, 10.0),

--- a/tests/fields/sortedset.py
+++ b/tests/fields/sortedset.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from limpyd import fields
-from limpyd.exceptions import UniquenessError
+from limpyd.exceptions import LimpydException, UniquenessError
 
 from ..model import TestRedisModel, BaseModelTest
 
@@ -9,6 +9,100 @@ from ..model import TestRedisModel, BaseModelTest
 class SortedSetModel(TestRedisModel):
     field = fields.SortedSetField(indexable=True)
 
+
+class SpecialZaddArgumentsTest(BaseModelTest):
+
+    model = SortedSetModel
+
+    def test_passing_mapping_as_unnamed_arg(self):
+        obj = self.model()
+        # only the mapping
+        count = obj.field.zadd({'foo': 1})
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 1.0),
+        ])
+        self.assertEqual(count, 1)  # one added
+        # if we change, count will be zero (counts only added)
+        count = obj.field.zadd({'foo': 2})
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 2.0),
+        ])
+        self.assertEqual(count, 0)  # zero added
+        # if we change and add, count is one
+        count = obj.field.zadd({'foo': 2, 'bar': 3})
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 2.0), ('bar', 3.0)
+        ])
+        self.assertEqual(count, 1)  # one added
+        # with ch, count includes changed
+        count = obj.field.zadd({'foo': 2.1, 'qux': 4}, True)
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 2.1), ('bar', 3.0), ('qux', 4.0)
+        ])
+        self.assertEqual(count, 2)  # one added and one changed
+        # ch can be passed as kwargs
+        count = obj.field.zadd({'foo': 2.2, 'xxx': 5}, ch=True)
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 2.2), ('bar', 3.0), ('qux', 4.0), ('xxx', 5.0)
+        ])
+        self.assertEqual(count, 2)  # one added and one changed
+        # only two args max accepted
+        with self.assertRaises(LimpydException):
+            obj.field.zadd({'foo': 2.2, 'xxx': 5}, True, False)
+        # if ch as kwarg, only one arg accepted
+        with self.assertRaises(LimpydException):
+            obj.field.zadd({'foo': 2.2, 'xxx': 5}, True, ch=True)
+        # only ch is accepted as kwarg
+        with self.assertRaises(LimpydException):
+            obj.field.zadd({'foo': 2.2, 'xxx': 5}, nx=True)
+        # cannot pass mapping as arg and kwarg
+        with self.assertRaises(LimpydException):
+            obj.field.zadd({'foo': 2.2, 'xxx': 5}, mapping={'x': 1, 'y': 2})
+
+    def test_passing_value_score_as_named_arguments(self):
+        obj = self.model()
+        # one value
+        count = obj.field.zadd(foo=1)
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 1.0),
+        ])
+        self.assertEqual(count, 1)  # one added
+        # many values
+        count = obj.field.zadd(foo=1.1, bar=2, baz=3)
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 1.1), ('bar', 2.0), ('baz', 3.0)
+        ])
+        self.assertEqual(count, 2)  # two added
+        # can pass ch
+        count = obj.field.zadd(foo=1.2, xxx=4, ch=True)
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 1.2), ('bar', 2.0), ('baz', 3.0), ('xxx', 4.0)
+        ])
+        self.assertEqual(count, 2)  # one added and one changed
+        # but not other flags
+        with self.assertRaises(LimpydException):
+            obj.field.zadd(foo=1.2, xxx=4, nx=True)
+        # it doesn't work if a mapping is passed too
+        with self.assertRaises(TypeError):
+            obj.field.zadd(mapping={'x': 1, 'y': 2}, foo=1.2, xxx=4)
+
+    def test_passing_mapping_as_kwarg(self):
+        obj = self.model()
+        # one value
+        count = obj.field.zadd(mapping={'foo': 1})
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 1.0),
+        ])
+        self.assertEqual(count, 1)  # one added
+        # can pass ch
+        count = obj.field.zadd(mapping={'foo': 1.1, 'bar': 2}, ch=True)
+        self.assertEqual(obj.field.zrange(0, -1, withscores=True), [
+            ('foo', 1.1), ('bar', 2)
+        ])
+        self.assertEqual(count, 2)  # one added and one changed
+        # but not other flags
+        with self.assertRaises(LimpydException):
+            obj.field.zadd(mapping={'foo': 1.1, 'bar': 2}, nx=True)
 
 class IndexableSortedSetFieldTest(BaseModelTest):
 
@@ -19,16 +113,11 @@ class IndexableSortedSetFieldTest(BaseModelTest):
         self.assertCollection([obj._pk], field='foo')
         self.assertCollection([obj._pk], field='bar')
 
-    def test_sortedset_can_be_set_at_init_from_a_list(self):
-        obj = self.model(field=[1, 'foo', 2, 'bar'])
-        self.assertCollection([obj._pk], field='foo')
-        self.assertCollection([obj._pk], field='bar')
-
     def test_indexable_sorted_sets_are_indexed(self):
         obj = self.model()
 
         # add one value
-        obj.field.zadd(1.0, 'foo')
+        obj.field.zadd(foo=1.0)
         self.assertCollection([obj._pk], field='foo')
         self.assertCollection([], field='bar')
 
@@ -36,7 +125,7 @@ class IndexableSortedSetFieldTest(BaseModelTest):
         with self.assertNumCommands(2 + self.COUNT_LOCK_COMMANDS):
             # check that only 2 commands occured: zadd + index of value
             # + n for the lock (set at the biginning, check/unset at the end))
-            obj.field.zadd(2.0, 'bar')
+            obj.field.zadd({'bar': 2.0})
         # check collections
         self.assertCollection([obj._pk], field='foo')
         self.assertCollection([obj._pk], field='bar')
@@ -64,13 +153,22 @@ class IndexableSortedSetFieldTest(BaseModelTest):
         with self.assertNumCommands(2 + self.COUNT_LOCK_COMMANDS):
             # check that we had only 2 commands: one for zincr, one for indexing the value
             # + n for the lock (set at the biginning, check/unset at the end))
-            obj.field.zincrby('foo', 5.0)
+            obj.field.zincrby(5.0, 'foo')
+
+        # check new value in sorted set
+        self.assertEqual(obj.field.zscore('foo'), 5.0)
 
         # check that the new value is indexed
         self.assertCollection([obj._pk], field='foo')
 
         # check that the previous value was not deindexed
         self.assertCollection([obj._pk], field='ignorable')
+
+        # incr again...
+        with self.assertNumCommands(2 + self.COUNT_LOCK_COMMANDS):
+            obj.field.zincrby(4.4, 'foo')
+        self.assertEqual(obj.field.zscore('foo'), 9.4)
+        self.assertCollection([obj._pk], field='foo')
 
     def test_zremrange_reindex_all_values(self):
         obj = self.model()

--- a/tests/indexes.py
+++ b/tests/indexes.py
@@ -9,7 +9,7 @@ from limpyd.database import RedisDatabase
 from limpyd.exceptions import ImplementationError, UniquenessError
 from limpyd.indexes import EqualIndex, TextRangeIndex, NumberRangeIndex
 
-from .base import LimpydBaseTest, TEST_CONNECTION_SETTINGS, skip_if_no_zrangebylex
+from .base import LimpydBaseTest, TEST_CONNECTION_SETTINGS
 from .model import Bike, Email, TestRedisModel, Boat
 
 
@@ -212,7 +212,6 @@ class RangeIndexTestModel(TestRedisModel):
     value = fields.StringField(indexable=True, indexes=[NumberRangeIndex])
 
 
-@unittest.skipIf(*skip_if_no_zrangebylex)
 class TextRangeIndexTestCase(LimpydBaseTest):
 
     def setUp(self):
@@ -449,7 +448,6 @@ class TextRangeIndexTestCase(LimpydBaseTest):
         })
 
 
-@unittest.skipIf(*skip_if_no_zrangebylex)
 class NumberRangeIndexTestCase(LimpydBaseTest):
 
     def setUp(self):
@@ -881,7 +879,6 @@ class CleanTestCase(LimpydBaseTest):
         with self.assertRaises(AssertionError):
             CleanModel1().get_field('field')._indexes[0].rebuild()
 
-    @unittest.skipIf(*skip_if_no_zrangebylex)
     def test_range_index(self):
 
         class CleanModel2(TestRedisModel):
@@ -1144,7 +1141,6 @@ class InSuffixTestCase(LimpydBaseTest):
             {pk4}
         )
 
-    @unittest.skipIf(*skip_if_no_zrangebylex)
     def test_range_index(self):
 
         pk1 = RangeIndexTestModel(name="Pen Duick I", value=1898).pk.get()

--- a/tests/model.py
+++ b/tests/model.py
@@ -544,7 +544,7 @@ class PostCommandTest(LimpydBaseTest):
         def post_command(self, sender, name, result, args, kwargs):
             if isinstance(sender, fields.RedisField) and sender.name == "name":
                 if name in sender.available_modifiers:
-                    self.last_modification_date.hset(datetime.now())
+                    self.last_modification_date.hset(str(datetime.now()))
                 elif name == "hget":
                     result = "modifed_result"
             return result


### PR DESCRIPTION
Breaking changes:
- redis-py version >= 3 is required (checked on first redis call)
- redis-server >= 3 is required (checked on first redis call)
- zadd only accepts values only as a mapping or value=score
- zincrby arguments are swapped (now amount, value instead of value,
amount)

New features:
- zadd accepts the `ch` flag from redis-py to return number of
added+changed elements, not only added ones (but the other flags are not
supported)

Adapted:
- FieldLock, based on redis lock is now lua only
- No more override of redis.client.Lock, now limpyd.database.Lock IS
redis.client.Lock
- removed all conditions for things that only worked for redis-py>=2.10
- converted non str/float/int arguments to be passed to redis server as
it's not done by redis-py anymore (`None` in indexing and dates in
tests)